### PR TITLE
OR-5240 Built-In publisher `Just`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B76229D2130600CB89C8 /* CombineDemoTests.swift */; };
 		9642B76D29D2130600CB89C8 /* CombineDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B76C29D2130600CB89C8 /* CombineDemoUITests.swift */; };
 		9642B76F29D2130600CB89C8 /* CombineDemoUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B76E29D2130600CB89C8 /* CombineDemoUITestsLaunchTests.swift */; };
+		9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B77D29D2149A00CB89C8 /* JustTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		9642B76829D2130600CB89C8 /* CombineDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CombineDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B76C29D2130600CB89C8 /* CombineDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoUITests.swift; sourceTree = "<group>"; };
 		9642B76E29D2130600CB89C8 /* CombineDemoUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		9642B77D29D2149A00CB89C8 /* JustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,7 @@
 		9642B76129D2130600CB89C8 /* CombineDemoTests */ = {
 			isa = PBXGroup;
 			children = (
+				9642B77B29D2144800CB89C8 /* Publishers */,
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
 			);
 			path = CombineDemoTests;
@@ -127,6 +130,22 @@
 				9642B76E29D2130600CB89C8 /* CombineDemoUITestsLaunchTests.swift */,
 			);
 			path = CombineDemoUITests;
+			sourceTree = "<group>";
+		};
+		9642B77B29D2144800CB89C8 /* Publishers */ = {
+			isa = PBXGroup;
+			children = (
+				9642B77C29D2145B00CB89C8 /* BuiltInPublishers */,
+			);
+			path = Publishers;
+			sourceTree = "<group>";
+		};
+		9642B77C29D2145B00CB89C8 /* BuiltInPublishers */ = {
+			isa = PBXGroup;
+			children = (
+				9642B77D29D2149A00CB89C8 /* JustTests.swift */,
+			);
+			path = BuiltInPublishers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -269,6 +288,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
+				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/JustTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/JustTests.swift
@@ -21,8 +21,6 @@ final class JustTests: XCTestCase {
     }
 
     override func tearDown() {
-        subject.cancellables.forEach { $0.cancel() }
-        subject.cancellables.removeAll()
         justPublisher = nil
         subject = nil
 

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/JustTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/JustTests.swift
@@ -1,0 +1,104 @@
+//
+//  JustTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 27/03/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+final class JustTests: XCTestCase {
+    var justPublisher: Just<String>!
+    var subject: JustTestingViewModel<String>!
+
+    override func setUp() {
+        super.setUp()
+
+        justPublisher = Just("James bond")
+        subject = JustTestingViewModel(justPublisher)
+    }
+
+    override func tearDown() {
+        subject.cancellables.forEach { $0.cancel() }
+        subject.cancellables.removeAll()
+        justPublisher = nil
+        subject = nil
+
+        super.tearDown()
+    }
+
+    func testDefaultValue() {
+        XCTAssertFalse(subject.isFinishedCalled)
+        XCTAssertNil(subject.receivedValue)
+    }
+
+    func testValueAfterSink() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+    }
+
+    func testValueAfterReSink() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+
+        // Reset values
+        subject.isFinishedCalled = false
+        subject.receivedValue = "0"
+
+        // ReSink
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+    }
+
+
+    func testValueAfterReInitialized() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+
+        // Reset values
+        subject.isFinishedCalled = false
+        subject.receivedValue = "0"
+
+        // ReInitialized & Sink
+        justPublisher = Just("James Bond 007")
+        subject = JustTestingViewModel(justPublisher)
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James Bond 007")
+    }
+}
+
+final class JustTestingViewModel<OutputType> {
+    let justPublisher: Just<OutputType>
+    var cancellables: Set<AnyCancellable> = []
+
+    init(_ justPublisher: Just<OutputType>) {
+        self.justPublisher = justPublisher
+    }
+
+    var isFinishedCalled = false
+    var receivedValue: OutputType?
+
+    func performSink() {
+        justPublisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - [ ] Publisher
     - [x] Read about publisher https://github.com/crazymanish/what-matters-most/pull/58
-    - [ ] Built-in publishers
+    - [x] Built-in publishers https://github.com/crazymanish/what-matters-most/pull/59
     - [ ] Custom publisher
     - [ ] Practices
 - [ ] Subscriber


### PR DESCRIPTION
### Context
- Ticket: #3 
- `Just` is a built-in publisher that emits an output to each subscriber just once, and then finishes. 

### In this PR
- Built-In publisher `Just`
- https://developer.apple.com/documentation/combine/just/

### Testing steps
- Git checkout this pr git-branch
- Open the project and `cmd+u`

### Demo
<img width="700" alt="Screenshot 2023-03-27 at 21 06 43" src="https://user-images.githubusercontent.com/5364500/228041965-12f7348e-13a3-412c-aba0-27c55f04ce8f.png">

 
