### PR TITLE
OR-5240 Built-In publisher `Empty`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B77D29D2149A00CB89C8 /* JustTests.swift */; };
 		9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B77F29D2876200CB89C8 /* FutureTests.swift */; };
 		9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B78229D28DEA00CB89C8 /* DispatchQueueType.swift */; };
+		9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A429D365D100CB89C8 /* EmptyTests.swift */; };
+		9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A629D369A600CB89C8 /* ApiError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +53,8 @@
 		9642B77D29D2149A00CB89C8 /* JustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		9642B77F29D2876200CB89C8 /* FutureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FutureTests.swift; sourceTree = "<group>"; };
 		9642B78229D28DEA00CB89C8 /* DispatchQueueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueType.swift; sourceTree = "<group>"; };
+		9642B7A429D365D100CB89C8 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
+		9642B7A629D369A600CB89C8 /* ApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +152,7 @@
 		9642B77C29D2145B00CB89C8 /* BuiltInPublishers */ = {
 			isa = PBXGroup;
 			children = (
+				9642B7A429D365D100CB89C8 /* EmptyTests.swift */,
 				9642B77F29D2876200CB89C8 /* FutureTests.swift */,
 				9642B77D29D2149A00CB89C8 /* JustTests.swift */,
 			);
@@ -158,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				9642B78229D28DEA00CB89C8 /* DispatchQueueType.swift */,
+				9642B7A629D369A600CB89C8 /* ApiError.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -301,10 +307,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
+				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/EmptyTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/EmptyTests.swift
@@ -1,0 +1,73 @@
+//
+//  EmptyTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 28/03/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `Empty` is a built-in publisher that never publishes any values, and optionally finishes immediately.
+/// - https://developer.apple.com/documentation/combine/empty
+final class EmptyTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+
+        super.tearDown()
+    }
+
+    func testEmptyPublisherAsNever() {
+        // This is a ”Never” publisher — one which never sends values and never finishes or fails — because of the initializer Empty(completeImmediately: false).
+        let publisher = Empty<Int, Never>(completeImmediately: false)
+
+        var isFinishedCalled = false
+        var receivedValue: Int = -1
+
+        publisher.sink { completion in
+            switch completion {
+            case .finished:
+                isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertFalse(isFinishedCalled) // finished is not called
+        XCTAssertEqual(receivedValue, -1)
+    }
+
+    func testEmptyPublisherAsComplete() {
+        // This publisher will never sends values and but will finishes.
+        //
+        // This is very useful:
+        // When we want to say that a task is done and that task has been completed without passing a value.
+        let publisher = Empty<Int, Never>(completeImmediately: true)
+
+        var isFinishedCalled = false
+        var receivedValue: Int = -1
+
+        publisher.sink { completion in
+            switch completion {
+            case .finished:
+                isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled) // Tada: called
+        XCTAssertEqual(receivedValue, -1)
+    }
+}

--- a/CombineDemo/CombineDemoTests/TestHelpers/ApiError.swift
+++ b/CombineDemo/CombineDemoTests/TestHelpers/ApiError.swift
@@ -1,0 +1,27 @@
+//
+//  ApiError.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 28/03/2023.
+//
+
+import Foundation
+
+struct ApiError {
+    let code: ApiError.Code
+
+    init(code: ApiError.Code) {
+        self.code = code
+    }
+}
+
+extension ApiError {
+    enum Code: Int {
+        case notFound = 404
+        case notImplemented = 501
+    }
+}
+
+extension ApiError: Error {}
+extension ApiError: Equatable {}
+extension ApiError.Code: Equatable {}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - [ ] Publisher
     - [x] Read about publisher https://github.com/crazymanish/what-matters-most/pull/58
-    - [x] Built-in publishers (`Just` https://github.com/crazymanish/what-matters-most/pull/59, `Future` https://github.com/crazymanish/what-matters-most/pull/60)
+    - [x] Built-in publishers (`Just` https://github.com/crazymanish/what-matters-most/pull/59, `Future` https://github.com/crazymanish/what-matters-most/pull/60 , `Empty` https://github.com/crazymanish/what-matters-most/pull/61)
     - [ ] Custom publisher
     - [ ] Practices
 - [ ] Subscriber


### PR DESCRIPTION
### Context
- Ticket: #3 
- `Empty` is a built-in publisher that never publishes any values, and optionally finishes immediately.
- https://paigeshin1991.medium.com/swift-combine-empty-publisher-and-replaceempty-a58cd4db7c23

### In this PR
- Built-In publisher `Empty`
- https://developer.apple.com/documentation/combine/empty

### Testing steps
- Git checkout this pr git-branch
- Open the project and `cmd+u`

### Demo

<img width="752" alt="Screenshot 2023-03-28 at 20 59 25" src="https://user-images.githubusercontent.com/5364500/228340374-5d0edf4d-8c5c-459d-af33-27d9e7d79168.png">

