### PR TITLE
OR-5240 Built-In publisher `Deferred`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 		9642B77C29D2145B00CB89C8 /* BuiltInPublishers */ = {
 			isa = PBXGroup;
 			children = (
+				9631D1EA29D56B8600A9D790 /* DeferredTests.swift */,
 				9642B7A429D365D100CB89C8 /* EmptyTests.swift */,
 				9642B7F629D4C54600CB89C8 /* FailTests.swift */,
 				9642B77F29D2876200CB89C8 /* FutureTests.swift */,
@@ -312,6 +315,7 @@
 			files = (
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
+				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/DeferredTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/DeferredTests.swift
@@ -1,0 +1,102 @@
+//
+//  DeferredTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 30/03/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `Deferred` is a built-in publisher that awaits subscription before running the supplied closure to create a publisher for the new subscriber.
+/// - https://developer.apple.com/documentation/combine/deferred
+final class DeferredTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValue: Int?
+    var counter: Int!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+        counter = 0
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValue = nil
+        counter = nil
+
+        super.tearDown()
+    }
+
+    func testDeferredPublisher() {
+        let publisher = Deferred {
+            Future<Int, Never> { [weak self] promise in
+                guard let self else { fatalError() }
+
+                self.counter = self.counter+1
+                promise(.success(self.counter))
+            }
+        }
+
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, 1)
+    }
+
+    func testDeferredPublisherWithMultipleSink() {
+        let publisher = Deferred {
+            Future<Int, Never> { [weak self] promise in
+                guard let self else { fatalError() }
+
+                self.counter = self.counter+1
+                promise(.success(self.counter))
+            }
+        }
+
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, 1)
+
+        // Reset values
+        isFinishedCalled = false
+        receivedValue = nil
+
+        // ReSink again
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, 2) // Did you notice, Value is 2 means Deferred always create new publisher
+    }
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [x] Built-in publishers 
       - `Just` https://github.com/crazymanish/what-matters-most/pull/59, `Future` https://github.com/crazymanish/what-matters-most/pull/60  
       - `Empty` https://github.com/crazymanish/what-matters-most/pull/61, `Fail` https://github.com/crazymanish/what-matters-most/pull/62
+      - `Deferred` https://github.com/crazymanish/what-matters-most/pull/63
     - [ ] Custom publisher
     - [ ] Practices
 - [ ] Subscriber


### PR DESCRIPTION
### Context
- Ticket: #3 
- `Deferred` is a built-in publisher that awaits a subscription before running the supplied closure to create a publisher for the new subscriber.
- https://www.mikegopsill.com/posts/future-defer/#deferred

### In this PR
- Built-In publisher `Deferred`
- https://developer.apple.com/documentation/combine/deferred

### Testing steps
- Git checkout this pr git-branch
- Open the project and `cmd+u`

### Demo

<img width="816" alt="Screenshot 2023-03-30 at 09 15 01" src="https://user-images.githubusercontent.com/5364500/228758473-5854e268-68fc-4c2c-a67f-1d465a05b82a.png">

