### PR TITLE
OR-5240 Built-In publisher `Record`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
+		9631D28029D6242700A9D790 /* RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D27F29D6242700A9D790 /* RecordTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
+		9631D27F29D6242700A9D790 /* RecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				9642B7F629D4C54600CB89C8 /* FailTests.swift */,
 				9642B77F29D2876200CB89C8 /* FutureTests.swift */,
 				9642B77D29D2149A00CB89C8 /* JustTests.swift */,
+				9631D27F29D6242700A9D790 /* RecordTests.swift */,
 			);
 			path = BuiltInPublishers;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
+				9631D28029D6242700A9D790 /* RecordTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/RecordTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/RecordTests.swift
@@ -1,0 +1,113 @@
+//
+//  RecordTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 30/03/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `Record` is a built-in publisher that allows for recording a series of inputs and a completion, for later playback to each subscriber.
+/// - https://developer.apple.com/documentation/combine/record
+final class RecordTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedErrors: [ApiError]!
+    var receivedValues: [Int]!
+    var counter: Int!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+        receivedErrors = []
+        receivedValues = []
+        counter = 0
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedErrors = nil
+        receivedValues = nil
+        counter = nil
+
+        super.tearDown()
+    }
+
+    func testRecordPublisherWithFinished() {
+        let publisher = Record<Int, Never>(output: [1, 2, 3], completion: .finished)
+
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 3])
+    }
+
+    func testRecordPublisherWithError() {
+        let error = ApiError(code: .notFound)
+        let publisher = Record<Int, ApiError>(output: [1, 2, 3], completion: .failure(error))
+
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                self?.receivedErrors += [error]
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        XCTAssertFalse(isFinishedCalled) // Finished not get called
+        XCTAssertEqual(receivedErrors, [error])
+        XCTAssertEqual(receivedValues, [1, 2, 3])
+    }
+
+    func testRecordPublisherWithMultipleSink() {
+        let publisher = Record<Int, Never>(output: [1, 2, 3], completion: .finished)
+
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 3])
+
+        // Reset values
+        isFinishedCalled = false
+        receivedValues = []
+
+        // ReSink again
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 3])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
       - `Just` https://github.com/crazymanish/what-matters-most/pull/59, `Future` https://github.com/crazymanish/what-matters-most/pull/60  
       - `Empty` https://github.com/crazymanish/what-matters-most/pull/61, `Fail` https://github.com/crazymanish/what-matters-most/pull/62
       - `Deferred` https://github.com/crazymanish/what-matters-most/pull/63
+      - `Record` https://github.com/crazymanish/what-matters-most/pull/64
     - [ ] Custom publisher
     - [ ] Practices
 - [ ] Subscriber


### PR DESCRIPTION
### Context
- Ticket: #3 
- `Record` is a built-in publisher that allows for recording a series of inputs and a completion, for later playback to each subscriber.
- https://scotteg.github.io/using-record

### In this PR
- Built-In publisher `Record`
- https://developer.apple.com/documentation/combine/record

### Testing steps
- Git checkout this pr git-branch
- Open the project and `cmd+u`

### Demo

<img width="735" alt="Screenshot 2023-03-30 at 22 31 27" src="https://user-images.githubusercontent.com/5364500/228957320-1a9b9b12-e0d9-4295-881e-65275574278a.png">
