### PR TITLE
OR-5241 Custom publisher `DefaultValue`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
 		9631D28029D6242700A9D790 /* RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D27F29D6242700A9D790 /* RecordTests.swift */; };
+		9631D29329D7003C00A9D790 /* DefaultValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D29229D7003C00A9D790 /* DefaultValue.swift */; };
+		9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D29429D7036200A9D790 /* DefaultValueTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -44,6 +46,8 @@
 /* Begin PBXFileReference section */
 		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
 		9631D27F29D6242700A9D790 /* RecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTests.swift; sourceTree = "<group>"; };
+		9631D29229D7003C00A9D790 /* DefaultValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultValue.swift; sourceTree = "<group>"; };
+		9631D29429D7036200A9D790 /* DefaultValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultValueTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -88,6 +92,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9631D29129D6FFF500A9D790 /* CustomPublishers */ = {
+			isa = PBXGroup;
+			children = (
+				9631D29229D7003C00A9D790 /* DefaultValue.swift */,
+			);
+			path = CustomPublishers;
+			sourceTree = "<group>";
+		};
 		9642B74429D2130500CB89C8 = {
 			isa = PBXGroup;
 			children = (
@@ -111,6 +123,7 @@
 		9642B74F29D2130500CB89C8 /* CombineDemo */ = {
 			isa = PBXGroup;
 			children = (
+				9631D29129D6FFF500A9D790 /* CustomPublishers */,
 				9642B75029D2130500CB89C8 /* CombineDemoApp.swift */,
 				9642B75229D2130500CB89C8 /* ContentView.swift */,
 				9642B75429D2130600CB89C8 /* Assets.xcassets */,
@@ -158,6 +171,7 @@
 		9642B77C29D2145B00CB89C8 /* BuiltInPublishers */ = {
 			isa = PBXGroup;
 			children = (
+				9631D29429D7036200A9D790 /* DefaultValueTests.swift */,
 				9631D1EA29D56B8600A9D790 /* DeferredTests.swift */,
 				9642B7A429D365D100CB89C8 /* EmptyTests.swift */,
 				9642B7F629D4C54600CB89C8 /* FailTests.swift */,
@@ -308,6 +322,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9642B75329D2130500CB89C8 /* ContentView.swift in Sources */,
+				9631D29329D7003C00A9D790 /* DefaultValue.swift in Sources */,
 				9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -317,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
+				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,

--- a/CombineDemo/CombineDemo/CustomPublishers/DefaultValue.swift
+++ b/CombineDemo/CombineDemo/CustomPublishers/DefaultValue.swift
@@ -1,0 +1,51 @@
+//
+//  DefaultValue.swift
+//  CombineDemo
+//
+//  Created by Manish Rathi on 31/03/2023.
+//
+
+import Foundation
+import Combine
+
+/// - `DefaultValue` is a custom publisher that emits an output to each subscriber just once, and then finishes.
+/// - It works exactly same as Apple's built-in `Just` publisher
+/// - https://developer.apple.com/documentation/combine/just/
+struct DefaultValue<Output>: Publisher {
+    typealias Failure = Never
+
+    let output: Output
+
+    init(_ output: Output) {
+        self.output = output
+    }
+
+    func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+        let subscription = Subscription(output: output, subscriber: subscriber)
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+private extension DefaultValue {
+    final class Subscription<S: Subscriber> where S.Input == Output, S.Failure == Failure {
+        private let output: Output
+        private var subscriber: S?
+
+        init(output: Output, subscriber: S) {
+            self.output = output
+            self.subscriber = subscriber
+        }
+
+        func cancel() {
+            subscriber = nil
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            _ = subscriber?.receive(output)
+            _ = subscriber?.receive(completion: .finished)
+        }
+    }
+}
+
+extension DefaultValue.Subscription : Cancellable {}
+extension DefaultValue.Subscription : Subscription {}

--- a/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/DefaultValueTests.swift
+++ b/CombineDemo/CombineDemoTests/Publishers/BuiltInPublishers/DefaultValueTests.swift
@@ -1,0 +1,106 @@
+//
+//  DefaultValueTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 31/03/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+@testable import CombineDemo
+
+/// - `DefaultValue` is a custom publisher that emits an output to each subscriber just once, and then finishes.
+/// - It works exactly same as Apple's built-in `Just` publisher
+/// - https://developer.apple.com/documentation/combine/just/
+final class DefaultValueTests: XCTestCase {
+    var publisher: DefaultValue<String>!
+    var subject: DefaultValueTestingViewModel<String>!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = DefaultValue("James bond")
+        subject = DefaultValueTestingViewModel(publisher)
+    }
+
+    override func tearDown() {
+        publisher = nil
+        subject = nil
+
+        super.tearDown()
+    }
+
+    func testDefaultValue() {
+        XCTAssertFalse(subject.isFinishedCalled)
+        XCTAssertNil(subject.receivedValue)
+    }
+
+    func testValueAfterSink() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+    }
+
+    func testValueAfterReSink() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+
+        // Reset values
+        subject.isFinishedCalled = false
+        subject.receivedValue = "0"
+
+        // ReSink
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+    }
+
+
+    func testValueAfterReInitialized() {
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James bond")
+
+        // Reset values
+        subject.isFinishedCalled = false
+        subject.receivedValue = "0"
+
+        // ReInitialized & Sink
+        publisher = DefaultValue("James Bond 007")
+        subject = DefaultValueTestingViewModel(publisher)
+        subject.performSink()
+
+        XCTAssertTrue(subject.isFinishedCalled)
+        XCTAssertEqual(subject.receivedValue, "James Bond 007")
+    }
+}
+
+final class DefaultValueTestingViewModel<OutputType> {
+    let publisher: DefaultValue<OutputType>
+    var cancellables: Set<AnyCancellable> = []
+
+    init(_ publisher: DefaultValue<OutputType>) {
+        self.publisher = publisher
+    }
+
+    var isFinishedCalled = false
+    var receivedValue: OutputType?
+
+    func performSink() {
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+    }
+}


### PR DESCRIPTION
### Context
- Ticket: #4 
- `DefaultValue` is a custom publisher that emits an output to each subscriber just once, and then finishes.
- It works exactly the same as Apple's built-in `Just` publisher
- https://developer.apple.com/documentation/combine/just/
- https://thoughtbot.com/blog/lets-build-a-custom-publisher-in-combine

### In this PR
- Build a custom publisher `DefaultValue`

### Testing steps
- Git checkout this pr git-branch
- Open the project and `cmd+u`
