### PR TITLE
OR-5248 PassthroughSubject

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A429D365D100CB89C8 /* EmptyTests.swift */; };
 		9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A629D369A600CB89C8 /* ApiError.swift */; };
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
+		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +84,7 @@
 		9642B7A429D365D100CB89C8 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		9642B7A629D369A600CB89C8 /* ApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiError.swift; sourceTree = "<group>"; };
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
+		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +195,7 @@
 			children = (
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
 				9642B77B29D2144800CB89C8 /* Publishers */,
+				967AF3A72A485BF700AB60CA /* Subject */,
 				9631D2E729E6576A00A9D790 /* Subscriber */,
 				9642B78129D28DCE00CB89C8 /* TestHelpers */,
 			);
@@ -240,6 +243,14 @@
 				9631D2C329DD161500A9D790 /* URLSession+Decodable.swift */,
 			);
 			path = TestHelpers;
+			sourceTree = "<group>";
+		};
+		967AF3A72A485BF700AB60CA /* Subject */ = {
+			isa = PBXGroup;
+			children = (
+				967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */,
+			);
+			path = Subject;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -388,6 +399,7 @@
 				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
+				967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */,
 				9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */,
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Subject/PassthroughSubjectTests.swift
+++ b/CombineDemo/CombineDemoTests/Subject/PassthroughSubjectTests.swift
@@ -1,0 +1,179 @@
+//
+//  PassthroughSubject.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 25/06/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `PassthroughSubject` is a subject that broadcasts elements to downstream subscribers.
+/// - https://developer.apple.com/documentation/combine/passthroughsubject
+final class PassthroughSubjectTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedErrors: [ApiError]!
+    var receivedValues: [Int]!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+        receivedErrors = []
+        receivedValues = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedErrors = nil
+        receivedValues = nil
+
+        super.tearDown()
+    }
+
+    func testPassthroughSubjectWithFinished() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+        subject.send(completion: .finished) // sending finish
+        subject.send(3) // Trying to send value after finish
+
+        XCTAssertTrue(isFinishedCalled) // Finished got called correctly
+        XCTAssertEqual(receivedValues, [1, 2]) // received values before finish
+    }
+
+    func testPassthroughSubjectWithError() {
+        let subject = PassthroughSubject<Int, ApiError>()
+        let error = ApiError(code: .notFound)
+
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                self?.receivedErrors += [error]
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+        subject.send(completion: .failure(error)) // sending error
+        subject.send(3) // Trying to send value after error
+
+        XCTAssertFalse(isFinishedCalled) // Finished not get called
+        XCTAssertEqual(receivedErrors, [error]) // Error got called correctly
+        XCTAssertEqual(receivedValues, [1, 2]) // received values before error
+    }
+
+    func testPassthroughSubjectWithMultipleSink() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2])
+
+        // Reset values
+        isFinishedCalled = false
+        receivedValues = []
+
+        // ReSink again
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+        subject.send(completion: .finished) // sending finish
+        subject.send(3) // Trying to send value after finish
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 1, 2, 2]) // received 2 times for both sink (before finish, did not receive 3)
+    }
+
+    func testPassthroughSubjectWithMultipleSink2() {
+        let subject = PassthroughSubject<Int, Never>()
+
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+        subject.send(completion: .finished) // sending finish (2nd below sink will not work, already received finish)
+        subject.send(3) // Trying to send value after finish
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2])
+
+        // Reset values
+        isFinishedCalled = false
+        receivedValues = []
+
+        // ReSink again
+        subject.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // passing down new values with Subject
+        subject.send(1) // Sending value before finish
+        subject.send(2) // Sending value before finish
+        subject.send(completion: .finished) // sending finish
+        subject.send(3) // Trying to send value after finish
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, []) // Nothing received because already finished
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@
       - `IntSubscriber` https://github.com/crazymanish/what-matters-most/pull/74
 - [ ] Subject (Publisher & Subscriber)
     - [x] Read about subject https://github.com/crazymanish/what-matters-most/pull/75
-    - [ ] Built-in subjects
+    - [x] Built-in subjects
+      - `PassthroughSubject` https://github.com/crazymanish/what-matters-most/pull/76
+      - `CurrentValueSubject`
     - [ ] Custom subjects?
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #11  

### In this PR
- PassthroughSubject
- `PassthroughSubject` is a subject that broadcasts elements to downstream subscribers.
- https://developer.apple.com/documentation/combine/passthroughsubject
- https://paigeshin1991.medium.com/swift-combine-passthroughsubject-define-your-event-with-passthroughsubject-top-ios-dev-techniques-d1e11bc814ca

