### PR TITLE
OR-5251 TransformingOperators:: Collect

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		9631D2C429DD161500A9D790 /* URLSession+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2C329DD161500A9D790 /* URLSession+Decodable.swift */; };
 		9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2C529DEA8A200A9D790 /* AssignTests.swift */; };
 		9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */; };
+		96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F042A5AA32200C60D8A /* CollectTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -68,6 +69,7 @@
 		9631D2C329DD161500A9D790 /* URLSession+Decodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Decodable.swift"; sourceTree = "<group>"; };
 		9631D2C529DEA8A200A9D790 /* AssignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignTests.swift; sourceTree = "<group>"; };
 		9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntSubscriberTests.swift; sourceTree = "<group>"; };
+		96321F042A5AA32200C60D8A /* CollectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -151,6 +153,22 @@
 			path = CustomSubscriber;
 			sourceTree = "<group>";
 		};
+		96321F022A5AA2E100C60D8A /* Operators */ = {
+			isa = PBXGroup;
+			children = (
+				96321F032A5AA2F500C60D8A /* TransformingOperators */,
+			);
+			path = Operators;
+			sourceTree = "<group>";
+		};
+		96321F032A5AA2F500C60D8A /* TransformingOperators */ = {
+			isa = PBXGroup;
+			children = (
+				96321F042A5AA32200C60D8A /* CollectTests.swift */,
+			);
+			path = TransformingOperators;
+			sourceTree = "<group>";
+		};
 		9642B74429D2130500CB89C8 = {
 			isa = PBXGroup;
 			children = (
@@ -196,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
+				96321F022A5AA2E100C60D8A /* Operators */,
 				9642B77B29D2144800CB89C8 /* Publishers */,
 				967AF3A72A485BF700AB60CA /* Subject */,
 				9631D2E729E6576A00A9D790 /* Subscriber */,
@@ -397,6 +416,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */,
 				967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */,
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9631D2C229DD156A00A9D790 /* JSONDecodingTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/CollectTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/CollectTests.swift
@@ -1,0 +1,105 @@
+//
+//  CollectTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `collect()` The collect operator provides a convenient way to transform a stream of individual values from a publisher into an array of those values.
+/// - Collects all received elements, and emits a single array of the collection when the upstream publisher finishes.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/collect()
+final class CollectTests: XCTestCase {
+    var publisher: Publishers.Sequence<[Int], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValues: [Int]!
+    var receivedCollectedValues: [[Int]]!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = [10, 20, 15, 25, 5].publisher // Given: Publisher
+        cancellables = []
+        isFinishedCalled =  false
+        receivedValues = []
+        receivedCollectedValues = []
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValues = nil
+        receivedCollectedValues = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithoutCollectOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, 15, 25, 5].publisher
+
+        // When: Sink(Subscription)
+        publisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [10, 20, 15, 25, 5])
+    }
+
+    func testPublisherWithCollectOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, 15, 25, 5].publisher
+
+        // When: Sink(Subscription)
+        publisher
+            .collect() // Collect operator will collect all elements
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedCollectedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedCollectedValues, [[10, 20, 15, 25, 5]])
+    }
+
+    func testPublisherWithContidionalCollectOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, 15, 25, 5].publisher
+
+        // When: Sink(Subscription)
+        publisher
+            .collect(2) // Collect operator will collect only 2 values at a time
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedCollectedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedCollectedValues, [[10, 20], [15, 25], [5]])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
   **Section2: Operators**
 
 - [ ] Transforming Operators
-    - [ ] Collecting values
+    - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/78
     - [ ] Mapping values
     - [ ] Flattening publishers
     - [ ] Replacing/transforming upstream output


### PR DESCRIPTION
### Context
- Close ticket: #14 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Collect`
- `collect()` The collect operator provides a convenient way to transform a stream of individual values from a publisher into an array of those values.
- Collects all received elements, and emits a single array of the collection when the upstream publisher finishes.
- https://developer.apple.com/documentation/combine/publishers/collect/collect()

