### PR TITLE
OR-5252 TransformingOperators:: Map

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2C529DEA8A200A9D790 /* AssignTests.swift */; };
 		9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */; };
 		96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F042A5AA32200C60D8A /* CollectTests.swift */; };
+		96321F072A5AACA400C60D8A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F062A5AACA400C60D8A /* MapTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -70,6 +71,7 @@
 		9631D2C529DEA8A200A9D790 /* AssignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignTests.swift; sourceTree = "<group>"; };
 		9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntSubscriberTests.swift; sourceTree = "<group>"; };
 		96321F042A5AA32200C60D8A /* CollectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectTests.swift; sourceTree = "<group>"; };
+		96321F062A5AACA400C60D8A /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				96321F042A5AA32200C60D8A /* CollectTests.swift */,
+				96321F062A5AACA400C60D8A /* MapTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 			files = (
 				96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */,
 				967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */,
+				96321F072A5AACA400C60D8A /* MapTests.swift in Sources */,
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9631D2C229DD156A00A9D790 /* JSONDecodingTests.swift in Sources */,
 				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/MapTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/MapTests.swift
@@ -1,0 +1,84 @@
+//
+//  MapTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - Map Transforms all elements from the upstream publisher with a provided closure.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/map(_:)-8fi4q
+final class MapTests: XCTestCase {
+    var publisher: Publishers.Sequence<[Int], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = [10, 20, 15, 25, 5].publisher // Given: Publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMapOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, 15, 25, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .map { $0 * 2 } // map takes a closure that multiplies each value by 2
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues += [value]
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [20, 40, 30, 50, 10])
+    }
+
+    func testPublisherWithMapOperatorScenario2() {
+        // Given: Publisher
+        // let publisher = [10, 20, 15, 25, 5].publisher
+        var receivedValues: [String] = []
+        let romanNumeralDict = [10:"X", 20:"XX", 15:"XV", 25:"XXV"]
+
+        // map consumes each integer from the publisher and uses a dictionary to transform it from its numeral to a Roman equivalent, as a String.
+        // If the map(_:)’s closure fails to look up a Roman numeral, it returns the string (unknown).
+
+        // When: Sink(Subscription)
+        publisher
+            .map { romanNumeralDict[$0] ?? "(unknown)" }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["X", "XX", "XV", "XXV", "(unknown)"])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@
 
 - [ ] Transforming Operators
     - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/78
-    - [ ] Mapping values
+    - [x] Mapping values
+      - `map value` https://github.com/crazymanish/what-matters-most/pull/79
     - [ ] Flattening publishers
     - [ ] Replacing/transforming upstream output
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #15 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Map`
- `map` Transforms all elements from the upstream publisher with a provided closure.
- https://developer.apple.com/documentation/combine/publishers/collect/map(_:)-8fi4q
