### PR TITLE
OR-5252 TransformingOperators:: Map keypath

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */; };
 		96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F042A5AA32200C60D8A /* CollectTests.swift */; };
 		96321F072A5AACA400C60D8A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F062A5AACA400C60D8A /* MapTests.swift */; };
+		96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F082A5AB41200C60D8A /* MapKeypathTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -72,6 +73,7 @@
 		9631D2E929E657D500A9D790 /* IntSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntSubscriberTests.swift; sourceTree = "<group>"; };
 		96321F042A5AA32200C60D8A /* CollectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectTests.swift; sourceTree = "<group>"; };
 		96321F062A5AACA400C60D8A /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
+		96321F082A5AB41200C60D8A /* MapKeypathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKeypathTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 			children = (
 				96321F042A5AA32200C60D8A /* CollectTests.swift */,
 				96321F062A5AACA400C60D8A /* MapTests.swift */,
+				96321F082A5AB41200C60D8A /* MapKeypathTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -431,6 +434,7 @@
 				9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */,
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
+				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9631D29E29DB503900A9D790 /* URLSessionTests.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/MapKeypathTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/MapKeypathTests.swift
@@ -1,0 +1,61 @@
+//
+//  MapKeypathTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - Map Transforms all elements from the upstream publisher with a provided closure.
+/// - https://developer.apple.com/documentation/combine/publishers/mapkeypath
+/// - https://developer.apple.com/documentation/combine/publishers/collect/map(_:_:)
+final class MapKeypathTests: XCTestCase {
+    var publisher: Publishers.Sequence<[CGPoint], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = [CGPoint(x: 10, y: 5), CGPoint(x: 20, y: 50)].publisher // Given: Publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMapKeypathOperator() {
+        // Given: Publisher
+        // let publisher = [CGPoint(x: 10, y: 5), CGPoint(x: 20, y: 50)].publisher
+        var receivedXValues: [Double] = []
+        var receivedYValues: [Double] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .map(\.x, \.y) // using map(_:_:) to map into two key paths
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { xValue, yValue in
+            receivedXValues += [xValue]
+            receivedYValues += [yValue]
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedXValues, [10.0, 20.0])
+        XCTAssertEqual(receivedYValues, [5.0, 50.0])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
     - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/78
     - [x] Mapping values
       - `map value` https://github.com/crazymanish/what-matters-most/pull/79
+      - `map keypath value` https://github.com/crazymanish/what-matters-most/pull/80
     - [ ] Flattening publishers
     - [ ] Replacing/transforming upstream output
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #15 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Map keypath`
- `map` Transforms all elements from the upstream publisher with a provided closure.
- https://developer.apple.com/documentation/combine/publishers/mapkeypath
- https://developer.apple.com/documentation/combine/publishers/collect/map(_:_:)
