### PR TITLE
OR-5253 TransformingOperators:: flatMap

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F042A5AA32200C60D8A /* CollectTests.swift */; };
 		96321F072A5AACA400C60D8A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F062A5AACA400C60D8A /* MapTests.swift */; };
 		96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F082A5AB41200C60D8A /* MapKeypathTests.swift */; };
+		9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -76,6 +77,7 @@
 		96321F042A5AA32200C60D8A /* CollectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectTests.swift; sourceTree = "<group>"; };
 		96321F062A5AACA400C60D8A /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		96321F082A5AB41200C60D8A /* MapKeypathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKeypathTests.swift; sourceTree = "<group>"; };
+		9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMapTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				96321F062A5AACA400C60D8A /* MapTests.swift */,
 				96321F082A5AB41200C60D8A /* MapKeypathTests.swift */,
 				9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */,
+				9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
+				9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */,
 				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9631D29E29DB503900A9D790 /* URLSessionTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/FlatMapTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/FlatMapTests.swift
@@ -1,0 +1,194 @@
+//
+//  FlatMapTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `flatMap(maxPublishers:_:)` Transforms all elements from an upstream publisher into a new publisher up to a maximum number of publishers you specify.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/flatmap(maxpublishers:_:)-36djm
+final class FlatMapTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValues: [String]!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+        receivedValues = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValues = []
+
+        super.tearDown()
+    }
+
+    func testPublisherWithoutFlatMapOperator() {
+        let firstMessenger = Messenger(name: "No:1", message: "Hi, i am no:1")
+
+        // Given: Publisher
+        let chatPublisher = CurrentValueSubject<Messenger, Never>(firstMessenger)
+
+        // When: Sink(Subscription)
+        chatPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] messenger in
+            self?.receivedValues.append(messenger.message.value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["Hi, i am no:1"])
+    }
+
+    func testPublisherWithoutFlatMapOperatorScenario2() {
+        let firstMessenger = Messenger(name: "No:1", message: "Hi, i am no:1")
+        let secondMessenger = Messenger(name: "No:2", message: "Hi, i am no:2")
+
+        // Given: Publisher
+        let chatPublisher = CurrentValueSubject<Messenger, Never>(firstMessenger)
+
+        // When: Sink(Subscription)
+        chatPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] messenger in
+            self?.receivedValues.append(messenger.message.value)
+        }
+        .store(in: &cancellables)
+
+        // When:
+        firstMessenger.message.value = "No:1 has changed message"  // This is nested Publisher and is not received
+        chatPublisher.value = secondMessenger
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["Hi, i am no:1", "Hi, i am no:2"])
+    }
+
+    func testPublisherWithFlatMapOperator() {
+        let firstMessenger = Messenger(name: "No:1", message: "Hi, i am no:1")
+        let secondMessenger = Messenger(name: "No:2", message: "Hi, i am no:2")
+
+        // Given: Publisher
+        let chatPublisher = CurrentValueSubject<Messenger, Never>(firstMessenger)
+
+        // When: Sink(Subscription)
+        chatPublisher
+            .flatMap{ $0.message }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // When:
+        firstMessenger.message.value = "No:1 has changed message" // This is nested Publisher and will receive because of flatMap
+        chatPublisher.value = secondMessenger
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["Hi, i am no:1", "No:1 has changed message", "Hi, i am no:2"])
+    }
+
+    func testPublisherWithFlatMapOperatorScenario2() {
+        let firstMessenger = Messenger(name: "No:1", message: "Hi, i am no:1")
+        let secondMessenger = Messenger(name: "No:2", message: "Hi, i am no:2")
+
+        // Given: Publisher
+        let chatPublisher = CurrentValueSubject<Messenger, Never>(firstMessenger)
+
+        // When: Sink(Subscription)
+        chatPublisher
+            .flatMap{ $0.message }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // When:
+        firstMessenger.message.value = "No:1 has changed message" // This is nested Publisher and will receive because of flatMap
+        chatPublisher.value = secondMessenger
+
+        firstMessenger.message.value = "No:1 has changed message again"
+        secondMessenger.message.value = "No:2 has changed message too"
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["Hi, i am no:1", "No:1 has changed message", "Hi, i am no:2", "No:1 has changed message again", "No:2 has changed message too"])
+    }
+
+    func testPublisherWithFlatMapOperatorScenario3() {
+        let firstMessenger = Messenger(name: "No:1", message: "Hi, i am no:1")
+        let secondMessenger = Messenger(name: "No:2", message: "Hi, i am no:2")
+        let thirdMessenger = Messenger(name: "No:3", message: "Hi, i am no:3")
+
+        // Given: Publisher
+        let chatPublisher = CurrentValueSubject<Messenger, Never>(firstMessenger)
+
+        // When: Sink(Subscription)
+        chatPublisher
+            .flatMap(maxPublishers: .max(2)) { $0.message } // Adding here maximum two publishers (thirdMessenger will ignored)
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // When:
+        firstMessenger.message.value = "No:1 has changed message" // This is nested Publisher and will receive because of flatMap
+        chatPublisher.value = secondMessenger
+
+        firstMessenger.message.value = "No:1 has changed message again"
+        secondMessenger.message.value = "No:2 has changed message too"
+
+        chatPublisher.value = thirdMessenger // Let's try 3rd messenger
+        firstMessenger.message.value = "No:1 did not hear about No:3"
+        secondMessenger.message.value = "No:2 also did not receive the No:3 message"
+
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["Hi, i am no:1", "No:1 has changed message", "Hi, i am no:2", "No:1 has changed message again", "No:2 has changed message too", "No:1 did not hear about No:3", "No:2 also did not receive the No:3 message"])
+    }
+}
+
+struct Messenger {
+    let name: String
+    let message: CurrentValueSubject<String, Never>
+
+    init(name: String, message: String) {
+        self.name = name
+        self.message = CurrentValueSubject(message)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
       - `map value` https://github.com/crazymanish/what-matters-most/pull/79
       - `map keypath value` https://github.com/crazymanish/what-matters-most/pull/80
       - `tryMap value` https://github.com/crazymanish/what-matters-most/pull/81
-    - [ ] Flattening publishers
+    - [x] Flattening publishers https://github.com/crazymanish/what-matters-most/pull/82
     - [ ] Replacing/transforming upstream output
     - [ ] Practices
 - [ ] Filtering Operators


### PR DESCRIPTION
### Context
- Close ticket: #16 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: flatMap`
- `flatMap(maxPublishers:_:)` Transforms all elements from an upstream publisher into a new publisher up to a maximum number of publishers you specify.
- https://developer.apple.com/documentation/combine/publishers/collect/flatmap(maxpublishers:_:)-36djm
