### PR TITLE
OR-5253 TransformingOperators:: Replacing upstream output:: `replaceNil(with:)

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
 		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
+		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +98,7 @@
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
 		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
+		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +179,7 @@
 				96321F082A5AB41200C60D8A /* MapKeypathTests.swift */,
 				9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */,
 				9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */,
+				967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9631D2C229DD156A00A9D790 /* JSONDecodingTests.swift in Sources */,
 				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,
+				967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
 				967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/ReplaceNilTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/ReplaceNilTests.swift
@@ -1,0 +1,82 @@
+//
+//  ReplaceNilTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `replaceNil(with:)` Replaces nil elements in the stream with the provided element.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/replacenil(with:)
+final class ReplaceNilTests: XCTestCase {
+    var publisher: Publishers.Sequence<[Int?], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = [10, 20, nil, nil, 25].publisher // Given: Publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithReplaceNilOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, nil, nil, 25].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .replaceNil(with: 0) // Replace nil to 0
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [10, 20, 0, 0, 25])
+    }
+
+    func testPublisherWithReplaceNilWithMapOperator() {
+        // Given: Publisher
+        // let publisher = [10, 20, nil, nil, 25].publisher
+        var receivedValues: [String] = []
+        let romanNumeralDict = [10:"X", 20:"XX", 25:"XXV", 0:"0"]
+
+        // When: Sink(Subscription)
+        publisher
+            .replaceNil(with: 0) // Replace nil to 0
+            .map { romanNumeralDict[$0]! }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["X", "XX", "0", "0", "XXV"])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@
       - `map keypath value` https://github.com/crazymanish/what-matters-most/pull/80
       - `tryMap value` https://github.com/crazymanish/what-matters-most/pull/81
     - [x] Flattening publishers https://github.com/crazymanish/what-matters-most/pull/82
-    - [ ] Replacing/transforming upstream output
+    - [x] Replacing/transforming upstream output
+      - `replaceNil(with:)` https://github.com/crazymanish/what-matters-most/pull/83
     - [ ] Practices
 - [ ] Filtering Operators
     - [ ] Compacting and ignoring


### PR DESCRIPTION
### Context
- Close ticket: #17 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Replacing upstream output:: `replaceNil(with:)`
- `replaceNil(with:)` Replaces nil elements in the stream with the provided element.
- https://developer.apple.com/documentation/combine/publishers/collect/replacenil(with:)
