### PR TITLE
OR-5254 TransformingOperators:: Replacing upstream output:: `replaceEmpty(with:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
+		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
 		9631D28029D6242700A9D790 /* RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D27F29D6242700A9D790 /* RecordTests.swift */; };
 		9631D29329D7003C00A9D790 /* DefaultValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D29229D7003C00A9D790 /* DefaultValue.swift */; };
@@ -62,6 +63,7 @@
 
 /* Begin PBXFileReference section */
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
+		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
 		9631D27F29D6242700A9D790 /* RecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTests.swift; sourceTree = "<group>"; };
 		9631D29229D7003C00A9D790 /* DefaultValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultValue.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */,
 				9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */,
 				967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */,
+				9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -454,6 +457,7 @@
 				9631D2C429DD161500A9D790 /* URLSession+Decodable.swift in Sources */,
 				9631D28029D6242700A9D790 /* RecordTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
+				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				9631D29929D70D6A00A9D790 /* DefaultErrorTests.swift in Sources */,
 				9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TransformingOperators/ReplaceEmptyTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TransformingOperators/ReplaceEmptyTests.swift
@@ -1,0 +1,81 @@
+//
+//  ReplaceEmptyTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `replaceEmpty(with:)` Replaces an empty stream with the provided element.
+/// - Use replaceEmpty(with:) to provide a replacement element if the upstream publisher finishes without producing any elements.
+/// - Conversely, providing a non-empty publisher publishes all elements and the publisher then terminates normally.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/replaceempty(with:)
+final class ReplaceEmptyTests: XCTestCase {
+    var publisher: Publishers.Sequence<[Int], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithReplaceNilOperator() {
+        // Given: Publisher
+        publisher = [].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .replaceEmpty(with: 0) // Replace empty publisher to 0 for downstream
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [0])
+    }
+
+    func testPublisherWithReplaceNilWithMapOperator() {
+        // Given: Publisher
+        publisher = [10, 20].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .replaceEmpty(with: 0) // Will do nothing, because publisher is a non-empty and will publishes all elements and the publisher then terminates normally.
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [10, 20])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
     - [x] Flattening publishers https://github.com/crazymanish/what-matters-most/pull/82
     - [x] Replacing/transforming upstream output
       - `replaceNil(with:)` https://github.com/crazymanish/what-matters-most/pull/83
+      - `replaceEmpty(with:)` https://github.com/crazymanish/what-matters-most/pull/84
     - [ ] Practices
 - [ ] Filtering Operators
     - [ ] Compacting and ignoring


### PR DESCRIPTION
### Context
- Close ticket: #17 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Replacing upstream output:: replaceEmpty(with:)`
- `replaceEmpty(with:)` Replaces an empty stream with the provided element.
- Use replaceEmpty(with:) to provide a replacement element if the upstream publisher finishes without producing any elements.
- Conversely, providing a non-empty publisher publishes all elements and the publisher then terminates normally.
- https://developer.apple.com/documentation/combine/publishers/collect/replaceempty(with:)
