### PR TITLE
OR-5254 TransformingOperators:: Replacing upstream output:: `scan(initialResult, with:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
+		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
 		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
 		9631D28029D6242700A9D790 /* RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D27F29D6242700A9D790 /* RecordTests.swift */; };
 		9631D29329D7003C00A9D790 /* DefaultValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D29229D7003C00A9D790 /* DefaultValue.swift */; };
@@ -64,6 +65,7 @@
 /* Begin PBXFileReference section */
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
+		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
 		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
 		9631D27F29D6242700A9D790 /* RecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTests.swift; sourceTree = "<group>"; };
 		9631D29229D7003C00A9D790 /* DefaultValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultValue.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */,
 				967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */,
 				9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */,
+				9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */,
 			);
 			path = TransformingOperators;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 			files = (
 				96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */,
 				967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */,
+				9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */,
 				96321F072A5AACA400C60D8A /* MapTests.swift in Sources */,
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9631D2C229DD156A00A9D790 /* JSONDecodingTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
     - [x] Replacing/transforming upstream output
       - `replaceNil(with:)` https://github.com/crazymanish/what-matters-most/pull/83
       - `replaceEmpty(with:)` https://github.com/crazymanish/what-matters-most/pull/84
+      - `scan(initialResult, with:)` https://github.com/crazymanish/what-matters-most/pull/85
     - [ ] Practices
 - [ ] Filtering Operators
     - [ ] Compacting and ignoring


### PR DESCRIPTION
### Context
- Close ticket: #17 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `TransformingOperators:: Replacing upstream output:: scan(initialResult, with:)`
- `scan(_:_:)` Transforms elements from the upstream publisher by providing the current element to a closure along with the last value returned by the closure.
- https://developer.apple.com/documentation/combine/publishers/collect/scan(_:_:)
