### PR TITLE
OR-5256 FilteringOperators:: `filter(_:)  tryFilter(_:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
+		9612D6B52A5AFAD8007CBD1A /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B42A5AFAD8007CBD1A /* FilterTests.swift */; };
 		9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D1EA29D56B8600A9D790 /* DeferredTests.swift */; };
 		9631D28029D6242700A9D790 /* RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D27F29D6242700A9D790 /* RecordTests.swift */; };
 		9631D29329D7003C00A9D790 /* DefaultValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9631D29229D7003C00A9D790 /* DefaultValue.swift */; };
@@ -66,6 +67,7 @@
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
+		9612D6B42A5AFAD8007CBD1A /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
 		9631D1EA29D56B8600A9D790 /* DeferredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredTests.swift; sourceTree = "<group>"; };
 		9631D27F29D6242700A9D790 /* RecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTests.swift; sourceTree = "<group>"; };
 		9631D29229D7003C00A9D790 /* DefaultValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultValue.swift; sourceTree = "<group>"; };
@@ -130,6 +132,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9612D6B32A5AFA46007CBD1A /* FilteringOperators */ = {
+			isa = PBXGroup;
+			children = (
+				9612D6B42A5AFAD8007CBD1A /* FilterTests.swift */,
+			);
+			path = FilteringOperators;
+			sourceTree = "<group>";
+		};
 		9631D29129D6FFF500A9D790 /* CustomPublishers */ = {
 			isa = PBXGroup;
 			children = (
@@ -170,6 +180,7 @@
 		96321F022A5AA2E100C60D8A /* Operators */ = {
 			isa = PBXGroup;
 			children = (
+				9612D6B32A5AFA46007CBD1A /* FilteringOperators */,
 				96321F032A5AA2F500C60D8A /* TransformingOperators */,
 			);
 			path = Operators;
@@ -452,6 +463,7 @@
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
+				9612D6B52A5AFAD8007CBD1A /* FilterTests.swift in Sources */,
 				9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */,
 				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/FilteringOperators/FilterTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/FilteringOperators/FilterTests.swift
@@ -1,0 +1,97 @@
+//
+//  FilterTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `filter(_:)` Republishes all elements that match a provided closure.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/filter(_:)
+///
+/// - `tryFilter(_:)` Republishes all elements that match a provided error-throwing closure.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/tryfilter(_:)
+final class FilterTests: XCTestCase {
+    var publisher: Publishers.Sequence<ClosedRange<Int>, Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = (1...10).publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithFilterOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .filter { $0 % 3 == 0 } // Filter multiple of 3
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [3, 6, 9]) // Received filter values (multiple of 3)
+    }
+
+    func testPublisherWithTryFilterOperator() {
+        // Given: Publisher
+        // let publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryFilter { try self.isFoundInCache(value: $0) }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                receivedError = error as? ApiError
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, [1, 2, 3]) // 4 is not found in cache
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+
+    private func isFoundInCache(value: Int) throws -> Bool {
+        let cache = [1, 2, 3, 5, 6]
+
+        guard cache.contains(value) else {
+            throw ApiError(code: .notFound)
+        }
+
+        return true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@
       - `scan(initialResult, with:)` https://github.com/crazymanish/what-matters-most/pull/85
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/78, https://github.com/crazymanish/what-matters-most/pull/79, https://github.com/crazymanish/what-matters-most/pull/80, https://github.com/crazymanish/what-matters-most/pull/81, https://github.com/crazymanish/what-matters-most/pull/82, https://github.com/crazymanish/what-matters-most/pull/83, https://github.com/crazymanish/what-matters-most/pull/84, https://github.com/crazymanish/what-matters-most/pull/85
 - [ ] Filtering Operators
-    - [ ] Compacting and ignoring
-    - [ ] Filtering values
+    - [x] Compacting and ignoring
+      - `filter(_:) tryFilter(_:)` https://github.com/crazymanish/what-matters-most/pull/86
+    - [ ] Finding values
     - [ ] Droping values
     - [ ] Limiting values
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #19 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `FilteringOperators:: filter(_:)  tryFilter(_:)`
- `filter(_:)` Republishes all elements that match a provided closure.
- https://developer.apple.com/documentation/combine/publishers/collect/filter(_:)
- `tryFilter(_:)` Republishes all elements that match a provided error-throwing closure.
- https://developer.apple.com/documentation/combine/publishers/collect/tryfilter(_:)
