### PR TITLE
OR-5256 FilteringOperators:: `removeDuplicates(by:) tryRemoveDuplicates(by:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A429D365D100CB89C8 /* EmptyTests.swift */; };
 		9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A629D369A600CB89C8 /* ApiError.swift */; };
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
+		966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */; };
 		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
 		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
@@ -102,6 +103,7 @@
 		9642B7A429D365D100CB89C8 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		9642B7A629D369A600CB89C8 /* ApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiError.swift; sourceTree = "<group>"; };
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
+		966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDuplicateTests.swift; sourceTree = "<group>"; };
 		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
 		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				9612D6B42A5AFAD8007CBD1A /* FilterTests.swift */,
+				966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */,
 			);
 			path = FilteringOperators;
 			sourceTree = "<group>";
@@ -463,6 +466,7 @@
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
+				966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */,
 				9612D6B52A5AFAD8007CBD1A /* FilterTests.swift in Sources */,
 				9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */,
 				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/FilteringOperators/RemoveDuplicateTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/FilteringOperators/RemoveDuplicateTests.swift
@@ -1,0 +1,114 @@
+//
+//  RemoveDuplicateTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `removeDuplicates(by:)`Publishes only elements that don’t match the previous element, as evaluated by a provided closure.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/removeduplicates(by:)
+///
+/// - `tryRemoveDuplicates(by:)` Publishes only elements that don’t match the previous element, as evaluated by a provided error-throwing closure.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/tryremoveduplicates(by:)
+final class RemoveDuplicateTests: XCTestCase {
+    var publisher: Publishers.Sequence<[Int], Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = [0, 0, 0, 0, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4].publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithRemoveDuplicatesOperator() {
+        // Given: Publisher
+        // publisher = [0, 0, 0, 0, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .removeDuplicates() // Remove all duplicates
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [0, 1, 2, 3, 4])
+    }
+
+    func testPublisherWithRemoveDuplicatesOperatorScenario2() {
+        // Given: Publisher
+        // publisher = [0, 0, 0, 0, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .removeDuplicates { $0 == 3 && $1 == 3 } // Remove duplicate only for 3
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [0, 0, 0, 0, 1, 2, 2, 3, 4, 4, 4, 4])
+    }
+
+    func testPublisherWithTryRemoveDuplicatesOperator() {
+        // Given: Publisher
+        // publisher = [0, 0, 0, 0, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4].publisher
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryRemoveDuplicates {
+                if $0 == 3 && $1 == 3 { throw ApiError(code: .notFound) } // throwing error if there are duplicate of 3
+
+                return $0 == $1
+            }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                receivedError = error as? ApiError
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, [0, 1, 2, 3]) // after 3, nothing is received because of error
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/78, https://github.com/crazymanish/what-matters-most/pull/79, https://github.com/crazymanish/what-matters-most/pull/80, https://github.com/crazymanish/what-matters-most/pull/81, https://github.com/crazymanish/what-matters-most/pull/82, https://github.com/crazymanish/what-matters-most/pull/83, https://github.com/crazymanish/what-matters-most/pull/84, https://github.com/crazymanish/what-matters-most/pull/85
 - [ ] Filtering Operators
     - [x] Compacting and ignoring
-      - `filter(_:) tryFilter(_:)` https://github.com/crazymanish/what-matters-most/pull/86
+      - `filter(_:) tryFilter(_:)` https://github.com/crazymanish/what-matters-most/pull/87
+      - `removeDuplicates(by:) tryRemoveDuplicates(by:)` https://github.com/crazymanish/what-matters-most/pull/88
     - [ ] Finding values
     - [ ] Droping values
     - [ ] Limiting values


### PR DESCRIPTION
### Context
- Close ticket: #19 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `removeDuplicates(by:)`Publishes only elements that don’t match the previous element, as evaluated by a provided closure.
- https://developer.apple.com/documentation/combine/publishers/collect/removeduplicates(by:)
- `tryRemoveDuplicates(by:)` Publishes only elements that don’t match the previous element, as evaluated by a provided error-throwing closure.
- https://developer.apple.com/documentation/combine/publishers/collect/tryremoveduplicates(by:)
