### PR TITLE
OR-5257 FilteringOperators:: `Finding values`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */; };
 		966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784782A5B057F00398D70 /* CompactMapTests.swift */; };
 		9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */; };
+		9667847D2A5B27A800398D70 /* FindingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667847C2A5B27A800398D70 /* FindingValuesTests.swift */; };
 		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
 		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
@@ -108,6 +109,7 @@
 		966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDuplicateTests.swift; sourceTree = "<group>"; };
 		966784782A5B057F00398D70 /* CompactMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMapTests.swift; sourceTree = "<group>"; };
 		9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputTests.swift; sourceTree = "<group>"; };
+		9667847C2A5B27A800398D70 /* FindingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindingValuesTests.swift; sourceTree = "<group>"; };
 		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
 		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */,
 				966784782A5B057F00398D70 /* CompactMapTests.swift */,
 				9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */,
+				9667847C2A5B27A800398D70 /* FindingValuesTests.swift */,
 			);
 			path = FilteringOperators;
 			sourceTree = "<group>";
@@ -475,6 +478,7 @@
 				966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
 				966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */,
+				9667847D2A5B27A800398D70 /* FindingValuesTests.swift in Sources */,
 				9612D6B52A5AFAD8007CBD1A /* FilterTests.swift in Sources */,
 				9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */,
 				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/FilteringOperators/FindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/FilteringOperators/FindingValuesTests.swift
@@ -1,0 +1,199 @@
+//
+//  FindingValuesTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `first()` Publishes the first element of a stream, then finishes.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/first()
+/// - `first(where:)` Publishes the first element of a stream to satisfy a predicate closure, then finishes normally.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/first(where:)
+/// - `tryFirst(where:)` Publishes the first element of a stream to satisfy a throwing predicate closure, then finishes normally.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/tryfirst(where:)
+///
+/// - `last()` Publishes the last element of a stream, after the stream finishes.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/last()
+/// - `last(where:)` Publishes the last element of a stream that satisfies a predicate closure, after upstream finishes.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/last(where:)
+/// - `tryLast(where:)` Publishes the last element of a stream that satisfies an error-throwing predicate closure, after the stream finishes.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/trylast(where:)
+final class FindingValuesTests: XCTestCase {
+    var publisher: Publishers.Sequence<ClosedRange<Int>, Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = (1...10).publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithFirstOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .first()
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1]) // Received (first) b/w 1 to 10
+    }
+
+    func testPublisherWithFirstWhereOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .first(where: { $0 % 3 == 0 })  // filter (first) multiple of 3
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [3]) // Received (first) multiple of 3 b/w 1 to 10
+    }
+
+    func testPublisherWithTryFirstWhereOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryFirst(where: {
+                if $0 == 3 { throw ApiError(code: .notFound) }
+
+                return $0 % 4 == 0
+            })  // filter (first) multiple of 3
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                case .failure(let error):
+                    receivedError = error as? ApiError
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, []) // nothing is received because of error
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+
+    func testPublisherWithLastOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .last()
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [10]) // Received (last) b/w 1 to 10
+    }
+
+    func testPublisherWithLastWhereOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .last(where: { $0 % 3 == 0 })  // filter (last) multiple of 3
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [9]) // Received (last) multiple of 3 b/w 1 to 10
+    }
+
+    func testPublisherWithTryLastWhereOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryLast(where: {
+                if $0 == 3 { throw ApiError(code: .notFound) }
+
+                return $0 % 4 == 0
+            })  // filter (first) multiple of 3
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                case .failure(let error):
+                    receivedError = error as? ApiError
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, []) // nothing is received because of error
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@
       - `removeDuplicates(by:) tryRemoveDuplicates(by:)` https://github.com/crazymanish/what-matters-most/pull/88
       - `compactMap(_:) tryCompactMap(_:)` https://github.com/crazymanish/what-matters-most/pull/89
       - `ignoreOutput()` https://github.com/crazymanish/what-matters-most/pull/90
-    - [ ] Finding values
+    - [x] Finding values
+      - `first() first(where:) tryFirst(where:)` https://github.com/crazymanish/what-matters-most/pull/91
+      - `last() last(where:) tryLast(where:)` https://github.com/crazymanish/what-matters-most/pull/91
     - [ ] Droping values
     - [ ] Limiting values
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #20 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `FilteringOperators:: Finding values`
- `first()` Publishes the first element of a stream, then finishes.
- https://developer.apple.com/documentation/combine/publishers/collect/first()
- `first(where:)` Publishes the first element of a stream to satisfy a predicate closure, then finishes normally.
- https://developer.apple.com/documentation/combine/publishers/collect/first(where:)
- `tryFirst(where:)` Publishes the first element of a stream to satisfy a throwing predicate closure, then finishes normally.
- https://developer.apple.com/documentation/combine/publishers/collect/tryfirst(where:)
--------------------------------
- `last()` Publishes the last element of a stream, after the stream finishes.
- https://developer.apple.com/documentation/combine/publishers/collect/last()
- `last(where:)` Publishes the last element of a stream that satisfies a predicate closure, after upstream finishes.
- https://developer.apple.com/documentation/combine/publishers/collect/last(where:)
- `tryLast(where:)` Publishes the last element of a stream that satisfies an error-throwing predicate closure, after the stream finishes.
- https://developer.apple.com/documentation/combine/publishers/collect/trylast(where:)
