### PR TITLE
OR-5259 FilteringOperators:: `Limiting values`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		96321F072A5AACA400C60D8A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F062A5AACA400C60D8A /* MapTests.swift */; };
 		96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96321F082A5AB41200C60D8A /* MapKeypathTests.swift */; };
 		9638B7B52A5ABDEF005F01A0 /* FlatMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */; };
+		9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9641203E2A5B38AF00A69216 /* LimitingValuesTests.swift */; };
 		9642B75129D2130500CB89C8 /* CombineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75029D2130500CB89C8 /* CombineDemoApp.swift */; };
 		9642B75329D2130500CB89C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B75229D2130500CB89C8 /* ContentView.swift */; };
 		9642B75529D2130600CB89C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9642B75429D2130600CB89C8 /* Assets.xcassets */; };
@@ -90,6 +91,7 @@
 		96321F062A5AACA400C60D8A /* MapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		96321F082A5AB41200C60D8A /* MapKeypathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKeypathTests.swift; sourceTree = "<group>"; };
 		9638B7B42A5ABDEF005F01A0 /* FlatMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatMapTests.swift; sourceTree = "<group>"; };
+		9641203E2A5B38AF00A69216 /* LimitingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LimitingValuesTests.swift; sourceTree = "<group>"; };
 		9642B74D29D2130500CB89C8 /* CombineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CombineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9642B75029D2130500CB89C8 /* CombineDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineDemoApp.swift; sourceTree = "<group>"; };
 		9642B75229D2130500CB89C8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */,
 				9667847C2A5B27A800398D70 /* FindingValuesTests.swift */,
 				9667847E2A5B302E00398D70 /* DroppingValuesTests.swift */,
+				9641203E2A5B38AF00A69216 /* LimitingValuesTests.swift */,
 			);
 			path = FilteringOperators;
 			sourceTree = "<group>";
@@ -494,6 +497,7 @@
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
 				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
+				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,
 				9667847F2A5B302E00398D70 /* DroppingValuesTests.swift in Sources */,
 				9631D29929D70D6A00A9D790 /* DefaultErrorTests.swift in Sources */,
 				9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/FilteringOperators/LimitingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/FilteringOperators/LimitingValuesTests.swift
@@ -1,0 +1,185 @@
+//
+//  LimitingValuesTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 09/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - Limiting values means receiving values until some condition is met, and then forcing the publisher to complete.
+/// - For example, consider a request that may emit an unknown amount of values, but you only want a single emission and don’t care about the rest of them.
+/// - Combine solves this set of problems with the prefix family of operators.
+/// - This is opposite of dropping values operators: drop(), drop(while:), drop(:untilOutputFrom)
+///
+/// - `prefix(_:)` Republishes elements up to the specified maximum count.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/prefix(_:)
+/// - `prefix(while:)` Republishes elements while a predicate closure indicates publishing should continue.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/prefix(while:)
+/// - `tryPrefix(while:)` Republishes elements while an error-throwing predicate closure indicates publishing should continue.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/tryprefix(while:)
+/// - `prefix(untilOutputFrom:)` Republishes elements until another publisher emits an element.
+/// - https://developer.apple.com/documentation/combine/publishers/collect/prefix(untiloutputfrom:)
+final class LimitingValuesTests: XCTestCase {
+    var publisher: Publishers.Sequence<ClosedRange<Int>, Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = (1...10).publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithPrefixWithSpecificCountOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prefix(6)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 3, 4, 5, 6]) // received (first) 6 elements
+    }
+
+    func testPublisherWithPrefixWhileOperator() {
+        // Given: Publisher
+        // publisher = (1...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prefix(while: { $0 % 3 != 0 })
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2]) // received (while) [elements % 3 != 0]
+    }
+
+    func testPublisherWithTryPrefixWhileOperator() {
+        // Given: Publisher
+        let publisher = [1, 2, 3, 4, 5, 6, -1, 7, 8, 9, 10].publisher
+        let range: CountableClosedRange<Int> = (1...100)
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryPrefix {
+                guard $0 != 0 else { throw ApiError(code: .notFound) }
+                return range.contains($0)
+            }
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                case .failure(let error):
+                    receivedError = error as? ApiError
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled) // Successful finished
+        XCTAssertEqual(receivedValues, [1, 2, 3, 4, 5, 6])
+        XCTAssertNil(receivedError)
+    }
+
+    func testPublisherWithTryPrefixWhileOperatorScenario2() {
+        // Given: Publisher
+        let publisher = [1, 2, 3, 4, 5, 6, 0, -1, 7, 8, 9, 10].publisher
+        let range: CountableClosedRange<Int> = (1...100)
+        var receivedValues: [Int] = []
+        var receivedError: ApiError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryDrop {
+                guard $0 != 0 else { throw ApiError(code: .notFound) }
+                return range.contains($0)
+            }
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                case .failure(let error):
+                    receivedError = error as? ApiError
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished not called, because it is finished with error
+        XCTAssertEqual(receivedValues, []) // Nothing received because of error
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+
+    func testPublisherWithTryPrefixUntilOutputFromOperator() {
+        // Given: Publisher
+        let firstPublisher = PassthroughSubject<Int,Never>()
+        let secondPublisher = PassthroughSubject<String,Never>()
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        firstPublisher
+            .prefix(untilOutputFrom: secondPublisher)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // It will receive all values of firstPublisher, until secondPublisher kicks-in
+        firstPublisher.send(1)
+        firstPublisher.send(2)
+        secondPublisher.send("This will kick-off the firstPublisher")
+        firstPublisher.send(3)
+        firstPublisher.send(4)
+        firstPublisher.send(completion: .finished)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled) // Successful finished
+        XCTAssertEqual(receivedValues, [1, 2]) // Received values only before the secondPublisher's output
+    }
+}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@
       - `dropFirst(_:)` https://github.com/crazymanish/what-matters-most/pull/92
       - `drop(while:) tryDrop(while:)` https://github.com/crazymanish/what-matters-most/pull/92
       - `drop(untilOutputFrom:)` https://github.com/crazymanish/what-matters-most/pull/92
-    - [ ] Limiting values
+    - [x] Limiting values
+      - `prefix(_:)` https://github.com/crazymanish/what-matters-most/pull/93
+      - `prefix(while:) tryPrefix(while:)` https://github.com/crazymanish/what-matters-most/pull/93
+      - `prefix(untilOutputFrom:)` https://github.com/crazymanish/what-matters-most/pull/93
     - [ ] Practices
 - [ ] Combining Operators
     - [ ] Combining


### PR DESCRIPTION
### Context
- Close ticket: #22 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- Limiting values means receiving values until some condition is met, and then forcing the publisher to complete.
- For example, consider a request that may emit an unknown amount of values, but you only want a single emission and don’t care about the rest of them.
- Combine solves this set of problems with the prefix family of operators.
- This is **opposite of** dropping values operators: drop(), drop(while:), drop(:untilOutputFrom)
-----------------------------
- `prefix(_:)` Republishes elements up to the specified maximum count.
- https://developer.apple.com/documentation/combine/publishers/collect/prefix(_:)
- `prefix(while:)` Republishes elements while a predicate closure indicates publishing should continue.
- https://developer.apple.com/documentation/combine/publishers/collect/prefix(while:)
- `tryPrefix(while:)` Republishes elements while an error-throwing predicate closure indicates publishing should continue.
- https://developer.apple.com/documentation/combine/publishers/collect/tryprefix(while:)
- `prefix(untilOutputFrom:)` Republishes elements until another publisher emits an element.
- https://developer.apple.com/documentation/combine/publishers/collect/prefix(untiloutputfrom:)
