### PR TITLE
OR-5256 Combining Operators:: `prepend(_:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
 		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
+		96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,6 +118,7 @@
 		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
 		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
+		96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrependingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +200,7 @@
 		96321F022A5AA2E100C60D8A /* Operators */ = {
 			isa = PBXGroup;
 			children = (
+				96AC4A2C2A5FB45100B2042E /* CombiningOperators */,
 				9612D6B32A5AFA46007CBD1A /* FilteringOperators */,
 				96321F032A5AA2F500C60D8A /* TransformingOperators */,
 			);
@@ -323,6 +326,14 @@
 				967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */,
 			);
 			path = Subject;
+			sourceTree = "<group>";
+		};
+		96AC4A2C2A5FB45100B2042E /* CombiningOperators */ = {
+			isa = PBXGroup;
+			children = (
+				96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */,
+			);
+			path = CombiningOperators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -477,6 +488,7 @@
 				967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
+				96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */,
 				967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */,
 				9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */,
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/PrependingTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/PrependingTests.swift
@@ -1,0 +1,151 @@
+//
+//  PrependingTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `prepend(_:)` Prefixes a publisher’s output with the specified values.
+/// - We’ll use them to add values that emit before any values from our original publisher.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/prepend(_:)
+final class PrependingTests: XCTestCase {
+    var publisher: Publishers.Sequence<ClosedRange<Int>, Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = (5...10).publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithPrependOperator() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prepend(1, 2)
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 5, 6, 7, 8, 9, 10]) // Received prepended values (1, 2)
+    }
+
+    func testPublisherWithPrependOperatorAsArray() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prepend([1, 2]) // As array
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 5, 6, 7, 8, 9, 10]) // Received prepended values (1, 2)
+    }
+
+    func testPublisherWithPrependOperatorAsSet() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prepend(Set(1...2)) // As Set
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 5, 6, 7, 8, 9, 10]) // Received prepended values (1, 2)
+    }
+
+    func testPublisherWithPrependOperatorAsStride() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prepend(stride(from: -1, to: 5, by: 2)) // As stride
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [-1, 1, 3, 5, 6, 7, 8, 9, 10]) // Received prepended values stride by 2
+    }
+
+    func testPublisherWithPrependOperatorAsCombination() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .prepend([20, 30]) // As array
+            .prepend(stride(from: -1, to: 5, by: 2)) // As stride
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [-1, 1, 3, 20, 30, 5, 6, 7, 8, 9, 10]) // Received prepended values correctly
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@
       - `prefix(untilOutputFrom:)` https://github.com/crazymanish/what-matters-most/pull/93
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/87, https://github.com/crazymanish/what-matters-most/pull/88, https://github.com/crazymanish/what-matters-most/pull/89, https://github.com/crazymanish/what-matters-most/pull/90, https://github.com/crazymanish/what-matters-most/pull/91, https://github.com/crazymanish/what-matters-most/pull/92, https://github.com/crazymanish/what-matters-most/pull/93, https://github.com/crazymanish/what-matters-most/pull/94
 - [ ] Combining Operators
-    - [ ] Combining
+    - [x] Combining
+      - `prepend(_:)` https://github.com/crazymanish/what-matters-most/pull/95
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: prepend(_:)`
- `prepend(_:)` Prefixes a publisher’s output with the specified values.
- We’ll use them to add values that emit before any values from our original publisher.
- https://developer.apple.com/documentation/combine/publishers/reduce/prepend(_:)
