### PR TITLE
OR-5261 Combining Operators:: prepend(Publisher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [ ] Combining Operators
     - [x] Combining
       - `prepend(_:)` https://github.com/crazymanish/what-matters-most/pull/95
+      - `prepend(Publisher)` https://github.com/crazymanish/what-matters-most/pull/96
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: prepend(Publisher)`
- If prepending publisher2 at the beginning of publisher1. Values from publisher1 emit only after publisher2 completes.
- https://developer.apple.com/documentation/combine/publishers/reduce/prepend(_:)
