### PR TITLE
OR-5256 Combining Operators:: append(_:)

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
 		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
 		96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */; };
+		96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +120,7 @@
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
 		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
 		96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrependingTests.swift; sourceTree = "<group>"; };
+		96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -332,6 +334,7 @@
 			isa = PBXGroup;
 			children = (
 				96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */,
+				96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */,
 			);
 			path = CombiningOperators;
 			sourceTree = "<group>";
@@ -511,6 +514,7 @@
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,
 				9667847F2A5B302E00398D70 /* DroppingValuesTests.swift in Sources */,
+				96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */,
 				9631D29929D70D6A00A9D790 /* DefaultErrorTests.swift in Sources */,
 				9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */,
 			);

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/AppendingTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/AppendingTests.swift
@@ -1,0 +1,240 @@
+//
+//  AppendingTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `append(_:)` Appends a publisher’s output with the specified elements.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/append(_:)
+final class AppendingTests: XCTestCase {
+    var publisher: Publishers.Sequence<ClosedRange<Int>, Never>!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        publisher = (5...10).publisher
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithAppendOperator() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .append(1, 2)
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 1, 2]) // Received appended values (1, 2)
+    }
+
+    func testPublisherWithAppendOperatorAsArray() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .append([1, 2]) // As array
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 1, 2]) // Received appended values (1, 2)
+    }
+
+    func testPublisherWithAppendOperatorAsSet() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .append(Set(1...2)) // As Set
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 1, 2]) // Received appended values (1, 2)
+    }
+
+    func testPublisherWithAppendOperatorAsStride() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .append(stride(from: -5, to: 5, by: 2)) // As stride
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, -5, -3, -1, 1, 3]) // Received appended values stride by 2
+    }
+
+    func testPublisherWithAppendOperatorAsCombination() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .append([20, 30]) // As array
+            .append(stride(from: -1, to: 5, by: 2)) // As stride
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 20, 30, -1, 1, 3]) // Received appended values correctly
+    }
+
+    func testPublisherWithAppendOperatorAsPublisher() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // Appending publisher2 at the beginning of publisher1. Values from publisher1 emit only after publisher2 completes.
+        let publisher2 = (11...12).publisher
+
+        // When: Sink(Subscription)
+        publisher
+            .append([20, 30]) // As array
+            .append(publisher2) // As Publisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 20, 30, 11, 12]) // Received appended values correctly
+    }
+
+    func testPublisherWithAppendOperatorAsSubjectWithoutComplete() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // Appending publisher2 at the beginning of publisher1. Values from publisher1 emit only after publisher2 completes.
+        let publisher2 = PassthroughSubject<Int, Never>()
+
+        // When: Sink(Subscription)
+        publisher
+            .append([20, 30]) // As array
+            .append(publisher2) // As Publisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending publisher2's subject value
+        publisher2.send(11)
+        publisher2.send(12)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // publisher2 is not yet finished/completed.
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 20, 30, 11, 12]) // Received appended values
+    }
+
+    func testPublisherWithAppendOperatorAsSubjectWithComplete() {
+        // Given: Publisher
+        // publisher = (5...10).publisher
+        var receivedValues: [Int] = []
+
+        // Appending publisher2 at the beginning of publisher1. Values from publisher1 emit only after publisher2 completes.
+        let publisher2 = PassthroughSubject<Int, Never>()
+
+        // When: Sink(Subscription)
+        publisher
+            .append([20, 30]) // As array
+            .append(publisher2) // As Publisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending publisher2's subject value
+        publisher2.send(11)
+        publisher2.send(12)
+        publisher2.send(completion: .finished) // Sending completion
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [5, 6, 7, 8, 9, 10, 20, 30, 11, 12]) // Received appended values
+    }
+}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
     - [x] Combining
       - `prepend(_:)` https://github.com/crazymanish/what-matters-most/pull/95
       - `prepend(Publisher)` https://github.com/crazymanish/what-matters-most/pull/96
+      - `append(_:)` https://github.com/crazymanish/what-matters-most/pull/97
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: append(_:)`
- `append(_:)` Appends a publisher’s output with the specified elements.
- https://developer.apple.com/documentation/combine/publishers/reduce/append(_:)
