### PR TITLE
OR-5261 Combining Operators:: `merge(with:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */; };
 		96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */; };
 		96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */; };
+		96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A332A5FD35400B2042E /* MergeWithTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrependingTests.swift; sourceTree = "<group>"; };
 		96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendingTests.swift; sourceTree = "<group>"; };
 		96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatestTests.swift; sourceTree = "<group>"; };
+		96AC4A332A5FD35400B2042E /* MergeWithTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -338,6 +340,7 @@
 				96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */,
 				96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */,
 				96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */,
+				96AC4A332A5FD35400B2042E /* MergeWithTests.swift */,
 			);
 			path = CombiningOperators;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,
 				967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,
+				96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */,
 				9631D1EB29D56B8600A9D790 /* DeferredTests.swift in Sources */,
 				96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */,
 				967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/MergeWithTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/MergeWithTests.swift
@@ -41,7 +41,7 @@ final class MergeWithTests: XCTestCase {
 
         // When: Sink(Subscription)
         publisher1
-            .merge(with: publisher2, publisher3) // Switching to latest Publisher
+            .merge(with: publisher2, publisher3) // merging publisher2 and publisher3
             .sink { [weak self] completion in
             switch completion {
             case .finished:

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/MergeWithTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/MergeWithTests.swift
@@ -1,0 +1,80 @@
+//
+//  MergeWithTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `merge(with:)` Combines elements from this publisher with those from another publisher of the same type, delivering an interleaved sequence of elements.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/merge(with:)
+/// - This operator interleaves emissions from `different publishers` of the `same type`.
+final class MergeWithTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMergeWithOperator() {
+        // Given: Publishers
+        // Create three PassthroughSubjects that accept integers and no errors.
+        let publisher1 = PassthroughSubject<Int, Never>()
+        let publisher2 = PassthroughSubject<Int, Never>()
+        let publisher3 = PassthroughSubject<Int, Never>()
+
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher1
+            .merge(with: publisher2, publisher3) // Switching to latest Publisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending publisher's value
+
+        // Send value 1 and 2 to publisher1.
+        publisher1.send(1)
+        publisher1.send(2)
+
+        publisher2.send(4)
+        publisher1.send(3) // Sending using publisher1 after publisher2's 4
+        publisher2.send(5)
+
+        publisher3.send(7)
+        publisher3.send(8)
+        publisher2.send(6) // Sending using publisher2 after publisher3's 7, 8
+        publisher3.send(9)
+
+        // Finally, you send a completion event to the publishers,
+        // This completes all active subscriptions.
+        publisher1.send(completion: .finished)
+        publisher2.send(completion: .finished)
+        publisher3.send(completion: .finished)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [1, 2, 4, 3, 5, 7, 8, 6, 9]) // Received merge values (see 3 and 6)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@
       - `prepend(_:)` https://github.com/crazymanish/what-matters-most/pull/95
       - `prepend(Publisher)` https://github.com/crazymanish/what-matters-most/pull/96
       - `append(_:)` https://github.com/crazymanish/what-matters-most/pull/97
-      - `switchToLatest` https://github.com/crazymanish/what-matters-most/pull/98
+      - `switchToLatest()` https://github.com/crazymanish/what-matters-most/pull/98
+      - `merge(with:)` https://github.com/crazymanish/what-matters-most/pull/99
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: merge(with:)`
- `merge(with:)` Combines elements from this publisher with those from another publisher of the same type, delivering an interleaved sequence of elements.
- https://developer.apple.com/documentation/combine/publishers/reduce/merge(with:)
- This operator interleaves emissions from `different publishers` of the `same type`.
