### PR TITLE
OR-5261 Combining Operators:: `combineLatest(_:_:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */; };
 		96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */; };
 		96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A332A5FD35400B2042E /* MergeWithTests.swift */; };
+		96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A452A60081500B2042E /* CombineLatestTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,6 +126,7 @@
 		96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendingTests.swift; sourceTree = "<group>"; };
 		96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatestTests.swift; sourceTree = "<group>"; };
 		96AC4A332A5FD35400B2042E /* MergeWithTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
+		96AC4A452A60081500B2042E /* CombineLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -341,6 +343,7 @@
 				96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */,
 				96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */,
 				96AC4A332A5FD35400B2042E /* MergeWithTests.swift */,
+				96AC4A452A60081500B2042E /* CombineLatestTests.swift */,
 			);
 			path = CombiningOperators;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */,
 				9631D2C629DEA8A200A9D790 /* AssignTests.swift in Sources */,
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
+				96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/CombineLatestTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/CombineLatestTests.swift
@@ -1,0 +1,85 @@
+//
+//  CombineLatestTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `combineLatest(_:_:)` Subscribes to an additional publisher and invokes a closure upon receiving output from either publisher.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/combinelatest(_:_:)-65rrl
+/// - Tip: The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
+///
+/// - Use combineLatest<P,T>(_:) to combine the current and one additional publisher and transform them using a closure you specify to publish a new value to the downstream.
+/// - The combined publisher passes through any requests to all upstream publishers. However, it still obeys the demand-fulfilling rule of only sending the request amount downstream. If the demand isn’t .unlimited, it drops values from upstream publishers. It implements this by using a buffer size of 1 for each upstream, and holds the most-recent value in each buffer.
+/// - In the example below, combineLatest() receives the most-recent values published by the two publishers, it multiplies them together, and republishes the result:
+final class CombineLatestTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithSwitchToLatestOperator() {
+        // Given: Publishers
+        // Create two PassthroughSubjects. The first accepts integers with no errors, while the second accepts strings with no errors.
+        let publisher1 = PassthroughSubject<Int, Never>()
+        let publisher2 = PassthroughSubject<String, Never>()
+
+        var receivedValues: [String] = []
+
+        // When: Sink(Subscription)
+        // Combine the latest emissions of publisher2 with publisher1. You may combine up to four different publishers using different overloads of combineLatest.
+        publisher1
+            .combineLatest(publisher2) // Combining the latest Publisher's value
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { p1IntValue, p2StringValue in
+            let combinedValue = String(p1IntValue) + ":" + p2StringValue // combining here
+            receivedValues.append(combinedValue)
+        }
+        .store(in: &cancellables)
+
+        // Sending publisher's value
+
+        // Send 1 and 2 to publisher1,
+        publisher1.send(1) // Ignored: The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
+        publisher1.send(2)
+
+        // Send "a" and "b" to publisher2,
+        publisher2.send("a")
+        publisher2.send("b")
+
+        // Send 3 to publisher1
+        publisher1.send(3)
+
+        // and finally Send "c" to publisher2.
+        publisher2.send("c")
+
+        // Finally, you send a completion event to the current publisher1, publisher2,
+        // This completes all active subscriptions.
+        publisher1.send(completion: .finished)
+        publisher2.send(completion: .finished)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["2:a", "2:b", "3:b", "3:c"]) // Received combineLatest values
+    }
+}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
       - `append(_:)` https://github.com/crazymanish/what-matters-most/pull/97
       - `switchToLatest()` https://github.com/crazymanish/what-matters-most/pull/98
       - `merge(with:)` https://github.com/crazymanish/what-matters-most/pull/99
+      - `combineLatest(_:_:)` https://github.com/crazymanish/what-matters-most/pull/100
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: combineLatest(_:_:)`
- `combineLatest(_:_:)` Subscribes to an additional publisher and invokes a closure upon receiving output from either publisher.
- https://developer.apple.com/documentation/combine/publishers/reduce/combinelatest(_:_:)-65rrl
- **Tip:** The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
------------------------------
- Use combineLatest<P,T>(_:) to combine the current and one additional publisher and transform them using a closure you specify to publish a new value to the downstream.
- The combined publisher passes through any requests to all upstream publishers. However, it still obeys the demand-fulfilling rule of only sending the request amount downstream. If the demand isn’t .unlimited, it drops values from upstream publishers. It implements this by using a buffer size of 1 for each upstream, and holds the most-recent value in each buffer.
- In the example below, combineLatest() receives the most-recent values published by the two publishers, it multiplies them together, and republishes the result:
