### PR TITLE
OR-5261 Combining Operators:: `zip(_:)`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */; };
 		96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A332A5FD35400B2042E /* MergeWithTests.swift */; };
 		96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A452A60081500B2042E /* CombineLatestTests.swift */; };
+		96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA1B2A6019F2004404AE /* ZipTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +128,7 @@
 		96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatestTests.swift; sourceTree = "<group>"; };
 		96AC4A332A5FD35400B2042E /* MergeWithTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
 		96AC4A452A60081500B2042E /* CombineLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestTests.swift; sourceTree = "<group>"; };
+		96DACA1B2A6019F2004404AE /* ZipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -344,6 +346,7 @@
 				96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */,
 				96AC4A332A5FD35400B2042E /* MergeWithTests.swift */,
 				96AC4A452A60081500B2042E /* CombineLatestTests.swift */,
+				96DACA1B2A6019F2004404AE /* ZipTests.swift */,
 			);
 			path = CombiningOperators;
 			sourceTree = "<group>";
@@ -509,6 +512,7 @@
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
+				96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */,
 				966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */,
 				9667847D2A5B27A800398D70 /* FindingValuesTests.swift in Sources */,
 				9612D6B52A5AFAD8007CBD1A /* FilterTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/ZipTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/ZipTests.swift
@@ -1,5 +1,5 @@
 //
-//  CombineLatestTests.swift
+//  ZipTests.swift
 //  CombineDemoTests
 //
 //  Created by Manish Rathi on 13/07/2023.
@@ -9,14 +9,17 @@ import Foundation
 import Combine
 import XCTest
 
-/// - `combineLatest(_:_:)` Subscribes to an additional publisher and invokes a closure upon receiving output from either publisher.
-/// - https://developer.apple.com/documentation/combine/publishers/reduce/combinelatest(_:_:)-65rrl
-/// - Tip: The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
+/// - `zip(_:)`Combines elements from another publisher and deliver pairs of elements as tuples.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/zip(_:)
 ///
-/// - Use combineLatest<P,T>(_:) to combine the current and one additional publisher and transform them using a closure you specify to publish a new value to the downstream.
-/// - The combined publisher passes through any requests to all upstream publishers. However, it still obeys the demand-fulfilling rule of only sending the request amount downstream. If the demand isn’t .unlimited, it drops values from upstream publishers. It implements this by using a buffer size of 1 for each upstream, and holds the most-recent value in each buffer.
-/// - In the example below, combineLatest() receives the most-recent values published by the two publishers, it multiplies them together, and republishes the result:
-final class CombineLatestTests: XCTestCase {
+/// - Use zip(_:) to combine the latest elements from two publishers and emit a tuple to the downstream. The returned publisher waits until both publishers have emitted an event, then delivers the oldest unconsumed event from each publisher together as a tuple to the subscriber.
+/// - Much like a zipper or zip fastener on a piece of clothing pulls together rows of teeth to link the two sides, zip(_:) combines streams from two different publishers by linking pairs of elements from each side.
+/// - In this example, numbers and letters are PassthroughSubjects that emit values; once zip(_:) receives one value from each, it publishes the pair as a tuple to the downstream subscriber. It then waits for the next pair of values.
+///
+/// - You might recognize this one from the Swift standard library method with the same name on Sequence types.
+/// - This operator works similarly, emitting tuples of paired values in the same indexes. It waits for each publisher to emit an item, then emits a single tuple of items after all publishers have emitted an value at the current index.
+/// - This means that if you are zipping two publishers, you’ll get a single tuple emitted every time both publishers emit a value.
+final class ZipTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
     var isFinishedCalled: Bool!
 
@@ -34,7 +37,7 @@ final class CombineLatestTests: XCTestCase {
         super.tearDown()
     }
 
-    func testPublisherWithCombineLatestOperator() {
+    func testPublisherWithZipOperator() {
         // Given: Publishers
         // Create two PassthroughSubjects. The first accepts integers with no errors, while the second accepts strings with no errors.
         let publisher1 = PassthroughSubject<Int, Never>()
@@ -43,9 +46,8 @@ final class CombineLatestTests: XCTestCase {
         var receivedValues: [String] = []
 
         // When: Sink(Subscription)
-        // Combine the latest emissions of publisher2 with publisher1. You may combine up to four different publishers using different overloads of combineLatest.
         publisher1
-            .combineLatest(publisher2) // Combining the latest Publisher's value
+            .zip(publisher2) // zipping publisher2
             .sink { [weak self] completion in
             switch completion {
             case .finished:
@@ -60,7 +62,7 @@ final class CombineLatestTests: XCTestCase {
         // Sending publisher's value
 
         // Send 1 and 2 to publisher1,
-        publisher1.send(1) // Ignored: The combined publisher doesn’t produce elements until each of its upstream publishers publishes at least one element.
+        publisher1.send(1)
         publisher1.send(2)
 
         // Send "a" and "b" to publisher2,
@@ -80,6 +82,6 @@ final class CombineLatestTests: XCTestCase {
 
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
-        XCTAssertEqual(receivedValues, ["2:a", "2:b", "3:b", "3:c"]) // Received combineLatest values
+        XCTAssertEqual(receivedValues, ["1:a", "2:b", "3:c"]) // Received zipped values
     }
 }

--- a/CombineDemo/CombineDemoTests/Operators/CombiningOperators/ZipTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/CombiningOperators/ZipTests.swift
@@ -54,7 +54,7 @@ final class ZipTests: XCTestCase {
                 self?.isFinishedCalled = true
             }
         } receiveValue: { p1IntValue, p2StringValue in
-            let combinedValue = String(p1IntValue) + ":" + p2StringValue // combining here
+            let combinedValue = String(p1IntValue) + ":" + p2StringValue // combining zipping values
             receivedValues.append(combinedValue)
         }
         .store(in: &cancellables)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
       - `switchToLatest()` https://github.com/crazymanish/what-matters-most/pull/98
       - `merge(with:)` https://github.com/crazymanish/what-matters-most/pull/99
       - `combineLatest(_:_:)` https://github.com/crazymanish/what-matters-most/pull/100
+      - `zip(_:)` https://github.com/crazymanish/what-matters-most/pull/101
     - [ ] Practices
 - [ ] Time manipulation Operators
     - [ ] Shifting time


### PR DESCRIPTION
### Context
- Close ticket: #24 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Combining Operators:: zip(_:)`
- `zip(_:)`Combines elements from another publisher and deliver pairs of elements as tuples.
- https://developer.apple.com/documentation/combine/publishers/reduce/zip(_:)
------------------
- Use zip(_:) to combine the latest elements from two publishers and emit a tuple to the downstream. The returned publisher waits until both publishers have emitted an event, then delivers the oldest unconsumed event from each publisher together as a tuple to the subscriber.
- Much like a zipper or zip fastener on a piece of clothing pulls together rows of teeth to link the two sides, zip(_:) combines streams from two different publishers by linking pairs of elements from each side.
- In this example, numbers and letters are PassthroughSubjects that emit values; once zip(_:) receives one value from each, it publishes the pair as a tuple to the downstream subscriber. It then waits for the next pair of values.
----------------------
- You might recognize this one from the Swift standard library method with the same name on Sequence types.
- This operator works similarly, emitting tuples of paired values in the same indexes. It waits for each publisher to emit an item, then emits a single tuple of items after all publishers have emitted an value at the current index.
- This means that if you are zipping two publishers, you’ll get a single tuple emitted every time both publishers emit a value.
