### PR TITLE
OR-5263 Operators:: Time-manipulation Operators: Shifting time

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A332A5FD35400B2042E /* MergeWithTests.swift */; };
 		96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A452A60081500B2042E /* CombineLatestTests.swift */; };
 		96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA1B2A6019F2004404AE /* ZipTests.swift */; };
+		96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +130,7 @@
 		96AC4A332A5FD35400B2042E /* MergeWithTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
 		96AC4A452A60081500B2042E /* CombineLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestTests.swift; sourceTree = "<group>"; };
 		96DACA1B2A6019F2004404AE /* ZipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
+		96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftingTimeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -212,6 +214,7 @@
 			children = (
 				96AC4A2C2A5FB45100B2042E /* CombiningOperators */,
 				9612D6B32A5AFA46007CBD1A /* FilteringOperators */,
+				96DACA5D2A62D42A004404AE /* TimeManipulationOperators */,
 				96321F032A5AA2F500C60D8A /* TransformingOperators */,
 			);
 			path = Operators;
@@ -349,6 +352,14 @@
 				96DACA1B2A6019F2004404AE /* ZipTests.swift */,
 			);
 			path = CombiningOperators;
+			sourceTree = "<group>";
+		};
+		96DACA5D2A62D42A004404AE /* TimeManipulationOperators */ = {
+			isa = PBXGroup;
+			children = (
+				96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */,
+			);
+			path = TimeManipulationOperators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -528,6 +539,7 @@
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
 				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
+				96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */,
 				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,
 				9667847F2A5B302E00398D70 /* DroppingValuesTests.swift in Sources */,
 				96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/ShiftingTimeTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/ShiftingTimeTests.swift
@@ -1,0 +1,77 @@
+//
+//  ShiftingTimeTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 15/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `delay(for:tolerance:scheduler:options:)` Delays delivery of all output to the downstream receiver by a specified amount of time on a particular scheduler.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/delay(for:tolerance:scheduler:options:)
+///
+/// - Use delay(for:tolerance:scheduler:options:) when you need to delay the delivery of elements to a downstream by a specified amount of time.
+/// - In this example, a Timer publishes an event every second. The delay(for:tolerance:scheduler:options:) operator holds the delivery of the initial element for 3 seconds (±0.5 seconds), after which each element is delivered to the downstream on the main run loop after the specified delay:
+final class ShiftingTimeTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithDelayOperator() {
+        let expectation = XCTestExpectation(description: "Testing delay operator")
+
+        var sentValues: [String] = []
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .long
+
+        Timer.publish(every: 1.0, on: .main, in: .default)
+            .autoconnect()
+            .handleEvents(receiveOutput: { date in
+                let dateTimeValue = (dateFormatter.string(from: date))
+                sentValues.append(dateTimeValue)
+            })
+            .delay(for: .seconds(3), scheduler: RunLoop.main, options: .none)
+            .collect(2)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { values in
+                let now = Date()
+
+                for (index, value) in values.enumerated() {
+                    let receivedDateTimeValue = dateFormatter.string(from: value)
+                    let receivedValueAfterDelay = String(format: "%.0f", now.timeIntervalSince(value))
+
+                    XCTAssertEqual(receivedDateTimeValue, sentValues[index]) // Received correct values in exactly same order after delay
+                    XCTAssertEqual(receivedValueAfterDelay, "\(4-index)") // Received after correct delay (diff is always 1 second because above Timer is publishing new value in every second)
+                }
+
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        XCTAssertFalse(isFinishedCalled) // Timer is not finished
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
       - `zip(_:)` https://github.com/crazymanish/what-matters-most/pull/101
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/95, https://github.com/crazymanish/what-matters-most/pull/96, https://github.com/crazymanish/what-matters-most/pull/97, https://github.com/crazymanish/what-matters-most/pull/98, https://github.com/crazymanish/what-matters-most/pull/99, https://github.com/crazymanish/what-matters-most/pull/100, https://github.com/crazymanish/what-matters-most/pull/101, https://github.com/crazymanish/what-matters-most/pull/102
 - [ ] Time manipulation Operators
-    - [ ] Shifting time
+    - [x] Shifting time https://github.com/crazymanish/what-matters-most/pull/103
     - [ ] Collecting values
     - [ ] Holding off events
     - [ ] Timing out


### PR DESCRIPTION
### Context
- Close ticket: #26 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Time-manipulation Operators: Shifting time` 
- `delay(for:tolerance:scheduler:options:)` Delays delivery of all output to the downstream receiver by a specified amount of time on a particular scheduler.
- https://developer.apple.com/documentation/combine/publishers/reduce/delay(for:tolerance:scheduler:options:)
------------------
- Use delay(for:tolerance:scheduler:options:) when you need to delay the delivery of elements to a downstream by a specified amount of time.
- In this example, a Timer publishes an event every second. The delay(for:tolerance:scheduler:options:) operator holds the delivery of the initial element for 3 seconds (±0.5 seconds), after which each element is delivered to the downstream on the main run loop after the specified delay: