### PR TITLE
OR-5264 Operators:: Time-manipulation Operators: CollectingValues by time

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A452A60081500B2042E /* CombineLatestTests.swift */; };
 		96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA1B2A6019F2004404AE /* ZipTests.swift */; };
 		96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */; };
+		96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA602A631884004404AE /* CollectByTimeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +132,7 @@
 		96AC4A452A60081500B2042E /* CombineLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestTests.swift; sourceTree = "<group>"; };
 		96DACA1B2A6019F2004404AE /* ZipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
 		96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftingTimeTests.swift; sourceTree = "<group>"; };
+		96DACA602A631884004404AE /* CollectByTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectByTimeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -358,6 +360,7 @@
 			isa = PBXGroup;
 			children = (
 				96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */,
+				96DACA602A631884004404AE /* CollectByTimeTests.swift */,
 			);
 			path = TimeManipulationOperators;
 			sourceTree = "<group>";
@@ -543,6 +546,7 @@
 				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,
 				9667847F2A5B302E00398D70 /* DroppingValuesTests.swift in Sources */,
 				96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */,
+				96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */,
 				9631D29929D70D6A00A9D790 /* DefaultErrorTests.swift in Sources */,
 				9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */,
 			);

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/CollectByTimeTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/CollectByTimeTests.swift
@@ -1,5 +1,5 @@
 //
-//  ShiftingTimeTests.swift
+//  CollectByTimeTests.swift
 //  CombineDemoTests
 //
 //  Created by Manish Rathi on 15/07/2023.
@@ -9,12 +9,13 @@ import Foundation
 import Combine
 import XCTest
 
-/// - `delay(for:tolerance:scheduler:options:)` Delays delivery of all output to the downstream receiver by a specified amount of time on a particular scheduler.
-/// - https://developer.apple.com/documentation/combine/publishers/reduce/delay(for:tolerance:scheduler:options:)
-///
-/// - Use delay(for:tolerance:scheduler:options:) when you need to delay the delivery of elements to a downstream by a specified amount of time.
-/// - In this example, a Timer publishes an event every second. The delay(for:tolerance:scheduler:options:) operator holds the delivery of the initial element for 3 seconds (±0.5 seconds), after which each element is delivered to the downstream on the main run loop after the specified delay:
-final class ShiftingTimeTests: XCTestCase {
+/// - `collect(_:options:)` Collects elements by a given time-grouping strategy, and emits a single array of the collection.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/collect(_:options:)
+/// - Use collect(_:options:) to emit arrays of elements on a schedule specified by a Scheduler and Stride that you provide. At the end of each scheduled interval, the publisher sends an array that contains the items it collected.
+/// - If the upstream publisher finishes before filling the buffer, the publisher sends an array that contains items it received. This may be fewer than the number of elements specified in the requested Stride.
+
+/// - If the upstream publisher fails with an error, this publisher forwards the error to the downstream receiver instead of sending its output.
+final class CollectByTimeTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
     var isFinishedCalled: Bool!
 
@@ -32,37 +33,35 @@ final class ShiftingTimeTests: XCTestCase {
         super.tearDown()
     }
 
-    func testPublisherWithDelayOperator() {
-        let expectation = XCTestExpectation(description: "Testing delay operator")
+    func testPublisherWithCollectByTimeOperator() {
+        let expectation = XCTestExpectation(description: "Testing collect with time strategy operator")
 
         var sentValues: [String] = []
-
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .none
         dateFormatter.timeStyle = .long
 
-        Timer.publish(every: 1.0, on: .main, in: .default)
+        Timer.publish(every: 1.0, on: .main, in: .common)
             .autoconnect()
             .handleEvents(receiveOutput: { date in
                 let dateTimeValue = (dateFormatter.string(from: date))
                 sentValues.append(dateTimeValue)
             })
-            .delay(for: .seconds(3), scheduler: RunLoop.main, options: .none)
-            .collect(2)
+            .collect(.byTime(DispatchQueue.main, .seconds(4))) // Collecting value
             .sink { [weak self] completion in
                 switch completion {
                 case .finished:
                     self?.isFinishedCalled = true
                 }
             } receiveValue: { values in
-                let now = Date()
+                print(sentValues) // Sent values
+                print("--------------")
+                print(values.map { dateFormatter.string(from: $0) }) // received values
 
                 for (index, value) in values.enumerated() {
                     let receivedDateTimeValue = dateFormatter.string(from: value)
-                    let receivedValueAfterDelay = String(format: "%.0f", now.timeIntervalSince(value))
 
                     XCTAssertEqual(receivedDateTimeValue, sentValues[index]) // Received correct values in exactly same order after delay
-                    XCTAssertEqual(receivedValueAfterDelay, "\(4-index)") // Received after correct delay (diff is always 1 second because above Timer is publishing new value in every second)
                 }
 
                 expectation.fulfill()

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/95, https://github.com/crazymanish/what-matters-most/pull/96, https://github.com/crazymanish/what-matters-most/pull/97, https://github.com/crazymanish/what-matters-most/pull/98, https://github.com/crazymanish/what-matters-most/pull/99, https://github.com/crazymanish/what-matters-most/pull/100, https://github.com/crazymanish/what-matters-most/pull/101, https://github.com/crazymanish/what-matters-most/pull/102
 - [ ] Time manipulation Operators
     - [x] Shifting time https://github.com/crazymanish/what-matters-most/pull/103
-    - [ ] Collecting values
+    - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/104
     - [ ] Holding off events
     - [ ] Timing out
     - [ ] Measuring time


### PR DESCRIPTION
### Context
- Close ticket: #27 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Time-manipulation Operators: CollectingValues by time` 
- `collect(_:options:)` Collects elements by a given time-grouping strategy, and emits a single array of the collection.
- https://developer.apple.com/documentation/combine/publishers/reduce/collect(_:options:)
------------------
- Use collect(_:options:) to emit arrays of elements on a schedule specified by a Scheduler and Stride that you provide. At the end of each scheduled interval, the publisher sends an array that contains the items it collected.
- If the upstream publisher finishes before filling the buffer, the publisher sends an array that contains items it received. This may be fewer than the number of elements specified in the requested Stride.