### PR TITLE
OR-5265 Operators:: Time-manipulation Operators: Holding off events (Debounce)

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA1B2A6019F2004404AE /* ZipTests.swift */; };
 		96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */; };
 		96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA602A631884004404AE /* CollectByTimeTests.swift */; };
+		96DACA632A63F942004404AE /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA622A63F942004404AE /* DebounceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +134,7 @@
 		96DACA1B2A6019F2004404AE /* ZipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
 		96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftingTimeTests.swift; sourceTree = "<group>"; };
 		96DACA602A631884004404AE /* CollectByTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectByTimeTests.swift; sourceTree = "<group>"; };
+		96DACA622A63F942004404AE /* DebounceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -361,6 +363,7 @@
 			children = (
 				96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */,
 				96DACA602A631884004404AE /* CollectByTimeTests.swift */,
+				96DACA622A63F942004404AE /* DebounceTests.swift */,
 			);
 			path = TimeManipulationOperators;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				9631D29E29DB503900A9D790 /* URLSessionTests.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9631D2A029DBC51600A9D790 /* UserDefaultTests.swift in Sources */,
+				96DACA632A63F942004404AE /* DebounceTests.swift in Sources */,
 				9631D2C429DD161500A9D790 /* URLSession+Decodable.swift in Sources */,
 				9631D28029D6242700A9D790 /* RecordTests.swift in Sources */,
 				96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/DebounceTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/DebounceTests.swift
@@ -1,0 +1,102 @@
+//
+//  DebounceTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `debounce(for:scheduler:options:)` Publishes elements only after a specified time interval elapses between events.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/debounce(for:scheduler:options:)
+/// - Use the debounce(for:scheduler:options:) operator to control the number of values and time between delivery of values from the upstream publisher.
+/// - This operator is useful to process bursty or high-volume event streams where you need to reduce the number of values delivered to the downstream to a rate you specify.
+///
+/// - Example: For example, you may want to send a search URL request that returns a list of items matching what’s typed in the text field.
+/// - But of course, you don’t want to send a request every time your user types a single letter! You need some kind of mechanism to help pick up on typed text only when the user is done typing for a while.
+/// - Combine offers two operators that can help you here: debounce and throttle.
+final class DebounceTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithDebounceOperator() {
+        let expectation = XCTestExpectation(description: "Testing debounce with time strategy operator")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.1, "He"),
+            (0.2, "Hel"),
+            (0.3, "Hell"),
+            (0.5, "Hello"),
+            (0.6, "Hello "),
+            (2.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 2.0 seconds.
+            (2.1, "Hello Wo"),
+            (2.2, "Hello Wor"),
+            (2.4, "Hello Worl"),
+            (2.5, "Hello World")
+          ]
+
+        let continuousPublisher = PassthroughSubject<String, Never>()
+        let debouncedPublisher = continuousPublisher.debounce(for: .seconds(1.0), scheduler: DispatchQueue.main)
+
+        var isContinuousPublisherFinishedCalled = false
+        var receivedDebouncedValues: [String] = []
+
+        continuousPublisher.sink { completion in
+            switch completion {
+            case .finished:
+                isContinuousPublisherFinishedCalled = true
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("continuousPublisher : \(value)")
+        }
+        .store(in: &cancellables)
+
+        debouncedPublisher.sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedDebouncedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending continuousPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                continuousPublisher.send(value)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for continuousPublisher
+            continuousPublisher.send(completion: .finished)
+
+            // Ensuring that only received debounced values, instead of all continuous values
+            XCTAssertEqual(receivedDebouncedValues, ["Hello ", "Hello World"])
+
+            XCTAssertTrue(isContinuousPublisherFinishedCalled) // continuousPublisher is finished
+            XCTAssertFalse(self.isFinishedCalled) // debouncedPublisher is not yet finished
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@
 - [ ] Time manipulation Operators
     - [x] Shifting time https://github.com/crazymanish/what-matters-most/pull/103
     - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/104
-    - [ ] Holding off events
+    - [x] Holding off events
+      - `debounce(for:scheduler:options:)` https://github.com/crazymanish/what-matters-most/pull/105
     - [ ] Timing out
     - [ ] Measuring time
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #28 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Operators:: Time-manipulation Operators: Holding off events (Debounce)` 
- `debounce(for:scheduler:options:)` Publishes elements only after a specified time interval elapses between events.
- https://developer.apple.com/documentation/combine/publishers/reduce/debounce(for:scheduler:options:)
------------------
- Use the debounce(for:scheduler:options:) operator to control the number of values and time between delivery of values from the upstream publisher.
- This operator is useful to process bursty or high-volume event streams where you need to reduce the number of values delivered to the downstream to a rate you specify.
------------------
- **For example**, you may want to send a search URL request that returns a list of items matching what’s typed in the text field.
- But of course, you don’t want to send a request every time your user types a single letter! You need some kind of mechanism to help pick up on typed text only when the user is done typing for a while.
- Combine offers two operators that can help you here: debounce and throttle.