### PR TITLE
OR-5265 Operators:: Time-manipulation Operators: Holding off events (Throttle)

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */; };
 		96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA602A631884004404AE /* CollectByTimeTests.swift */; };
 		96DACA632A63F942004404AE /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA622A63F942004404AE /* DebounceTests.swift */; };
+		96DACA652A640249004404AE /* ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA642A640249004404AE /* ThrottleTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +136,7 @@
 		96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftingTimeTests.swift; sourceTree = "<group>"; };
 		96DACA602A631884004404AE /* CollectByTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectByTimeTests.swift; sourceTree = "<group>"; };
 		96DACA622A63F942004404AE /* DebounceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTests.swift; sourceTree = "<group>"; };
+		96DACA642A640249004404AE /* ThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottleTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -364,6 +366,7 @@
 				96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */,
 				96DACA602A631884004404AE /* CollectByTimeTests.swift */,
 				96DACA622A63F942004404AE /* DebounceTests.swift */,
+				96DACA642A640249004404AE /* ThrottleTests.swift */,
 			);
 			path = TimeManipulationOperators;
 			sourceTree = "<group>";
@@ -545,6 +548,7 @@
 				96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
 				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
+				96DACA652A640249004404AE /* ThrottleTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */,
 				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/ThrottleTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/ThrottleTests.swift
@@ -1,0 +1,208 @@
+//
+//  ThrottleTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `throttle(for:scheduler:latest:)` Publishes either the most-recent or first element published by the upstream publisher in the specified time interval.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/throttle(for:scheduler:latest:)
+/// - Use throttle(for:scheduler:latest:) to selectively republish elements from an upstream publisher during an interval you specify. Other elements received from the upstream in the throttling interval aren’t republished.
+///
+/// - For example, you may want to send a search URL request that returns a list of items matching what’s typed in the text field.
+/// - But of course, you don’t want to send a request every time your user types a single letter! You need some kind of mechanism to help pick up on typed text only when the user is done typing for a while.
+/// - Combine offers two operators that can help you here: debounce and throttle.
+final class ThrottleTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithThrottleOperatorWithLatestValueAsFalse() {
+        let expectation = XCTestExpectation(description: "Testing throttle with time strategy operator")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.1, "He"),
+            (0.2, "Hel"),
+            (0.3, "Hell"),
+            (0.5, "Hello"),
+            (0.6, "Hello "),
+            (2.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 2.0 seconds.
+            (2.1, "Hello Wo"),
+            (2.2, "Hello Wor"),
+            (2.4, "Hello Worl"),
+            (2.5, "Hello World")
+          ]
+
+        let continuousPublisher = PassthroughSubject<String, Never>()
+        // throttle will kick-in after one second pause of continuousPublisher
+        let throttledPublisher = continuousPublisher.throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: false) // latest value is false
+
+        var isContinuousPublisherFinishedCalled = false
+        var receivedThrottledPublisherValues: [String] = []
+
+        continuousPublisher.sink { completion in
+            switch completion {
+            case .finished:
+                isContinuousPublisherFinishedCalled = true
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("continuousPublisher : \(value)")
+        }
+        .store(in: &cancellables)
+
+        throttledPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            print("throttledPublisher : \(value)")
+            receivedThrottledPublisherValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending continuousPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                continuousPublisher.send(value)
+            }
+        }
+
+        /*
+         0.0: continuousPublisher : H
+         ✅0.0: throttledPublisher : H // 👀
+         0.1: continuousPublisher : He
+         0.2: continuousPublisher : Hel
+         0.3: continuousPublisher : Hell
+         0.5: continuousPublisher : Hello
+         0.6: continuousPublisher : Hello
+         ✅1.0: throttledPublisher : He // Not using latest(last)-value as mentioned above 👀
+         2.0: continuousPublisher : Hello W
+         ✅2.0: throttledPublisher : Hello W // 👀
+         2.1: continuousPublisher : Hello Wo
+         2.2: continuousPublisher : Hello Wor
+         2.4: continuousPublisher : Hello Worl
+         2.5: continuousPublisher : Hello World
+         ✅3.0: throttledPublisher : Hello Wo // Not using latest(last)-value as mentioned above 👀
+         */
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for continuousPublisher
+            continuousPublisher.send(completion: .finished)
+
+            // Ensuring that only received throttled values, instead of all continuous values
+            XCTAssertEqual(receivedThrottledPublisherValues, ["H", "He", "Hello W", "Hello Wo"])
+
+            XCTAssertTrue(isContinuousPublisherFinishedCalled) // continuousPublisher is finished
+            XCTAssertFalse(self.isFinishedCalled) // throttledPublisher is not yet finished
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testPublisherWithThrottleOperatorWithLatestValueAsTrue() {
+        let expectation = XCTestExpectation(description: "Testing throttle with time strategy operator scenario2")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.1, "He"),
+            (0.2, "Hel"),
+            (0.3, "Hell"),
+            (0.5, "Hello"),
+            (0.6, "Hello "),
+            (2.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 2.0 seconds.
+            (2.1, "Hello Wo"),
+            (2.2, "Hello Wor"),
+            (2.4, "Hello Worl"),
+            (2.5, "Hello World")
+          ]
+
+        let continuousPublisher = PassthroughSubject<String, Never>()
+        // throttle will kick-in after one second pause of continuousPublisher
+        let throttledPublisher = continuousPublisher.throttle(for: .seconds(1.0), scheduler: DispatchQueue.main, latest: true) // latest value is true
+
+        var isContinuousPublisherFinishedCalled = false
+        var receivedThrottledPublisherValues: [String] = []
+
+        continuousPublisher.sink { completion in
+            switch completion {
+            case .finished:
+                isContinuousPublisherFinishedCalled = true
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("continuousPublisher : \(value)")
+        }
+        .store(in: &cancellables)
+
+        throttledPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            print("throttledPublisher : \(value)")
+            receivedThrottledPublisherValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending continuousPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                continuousPublisher.send(value)
+            }
+        }
+
+        /*
+         0.0: continuousPublisher : H
+         ✅0.0: throttledPublisher : H // latest(last)-value as mentioned above 👀
+         0.1: continuousPublisher : He
+         0.2: continuousPublisher : Hel
+         0.3: continuousPublisher : Hell
+         0.5: continuousPublisher : Hello
+         0.6: continuousPublisher : Hello
+         ✅1.0: throttledPublisher : Hello // latest(last)-value as mentioned above 👀 (debounce would have kicks-in at 1.6, instead of 1.0)
+         2.0: continuousPublisher : Hello W
+         ✅2.0: throttledPublisher : Hello W // latest(last)-value as mentioned above 👀 (debounce would have not kicks-in here because user is keep typing!)
+         2.1: continuousPublisher : Hello Wo
+         2.2: continuousPublisher : Hello Wor
+         2.4: continuousPublisher : Hello Worl
+         2.5: continuousPublisher : Hello World
+         ✅3.0: throttledPublisher : Hello World // latest(last)-value as mentioned above 👀 (debounce would have kicks-in at 3.5, instead of 3.0)
+         */
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for continuousPublisher
+            continuousPublisher.send(completion: .finished)
+
+            // Ensuring that only received throttled values, instead of all continuous values
+            XCTAssertEqual(receivedThrottledPublisherValues, ["H", "Hello ", "Hello W", "Hello World"])
+
+            XCTAssertTrue(isContinuousPublisherFinishedCalled) // continuousPublisher is finished
+            XCTAssertFalse(self.isFinishedCalled) // throttledPublisher is not yet finished
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
     - [x] Collecting values https://github.com/crazymanish/what-matters-most/pull/104
     - [x] Holding off events
       - `debounce(for:scheduler:options:)` https://github.com/crazymanish/what-matters-most/pull/105
+      - `throttle(for:scheduler:latest:)` https://github.com/crazymanish/what-matters-most/pull/106
     - [ ] Timing out
     - [ ] Measuring time
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #28 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Operators:: Time-manipulation Operators: Holding off events (Throttle)` 
- `throttle(for:scheduler:latest:)` Publishes either the most-recent or first element published by the upstream publisher in the specified time interval.
- https://developer.apple.com/documentation/combine/publishers/reduce/throttle(for:scheduler:latest:)
------------------
- Use throttle(for:scheduler:latest:) to selectively republish elements from an upstream publisher during an interval you specify. Other elements received from the upstream in the throttling interval aren’t republished.
------------------
- **For example**, you may want to send a search URL request that returns a list of items matching what’s typed in the text field.
- But of course, you don’t want to send a request every time your user types a single letter! You need some kind of mechanism to help pick up on typed text only when the user is done typing for a while.
- Combine offers two operators that can help you here: debounce and throttle.