### PR TITLE
OR-5266 Operators:: Time-manipulation Operators: Timeout

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA602A631884004404AE /* CollectByTimeTests.swift */; };
 		96DACA632A63F942004404AE /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA622A63F942004404AE /* DebounceTests.swift */; };
 		96DACA652A640249004404AE /* ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA642A640249004404AE /* ThrottleTests.swift */; };
+		96DACA672A640D37004404AE /* TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA662A640D37004404AE /* TimeoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -137,6 +138,7 @@
 		96DACA602A631884004404AE /* CollectByTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectByTimeTests.swift; sourceTree = "<group>"; };
 		96DACA622A63F942004404AE /* DebounceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTests.swift; sourceTree = "<group>"; };
 		96DACA642A640249004404AE /* ThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottleTests.swift; sourceTree = "<group>"; };
+		96DACA662A640D37004404AE /* TimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeoutTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -367,6 +369,7 @@
 				96DACA602A631884004404AE /* CollectByTimeTests.swift */,
 				96DACA622A63F942004404AE /* DebounceTests.swift */,
 				96DACA642A640249004404AE /* ThrottleTests.swift */,
+				96DACA662A640D37004404AE /* TimeoutTests.swift */,
 			);
 			path = TimeManipulationOperators;
 			sourceTree = "<group>";
@@ -515,6 +518,7 @@
 				96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */,
 				967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */,
 				9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */,
+				96DACA672A640D37004404AE /* TimeoutTests.swift in Sources */,
 				9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */,
 				96321F072A5AACA400C60D8A /* MapTests.swift in Sources */,
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/TimeoutTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/TimeoutTests.swift
@@ -1,0 +1,195 @@
+//
+//  TimeoutTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `timeout(_:scheduler:options:customError:)` Terminates publishing if the upstream publisher exceeds the specified time interval without producing an element.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/timeout(_:scheduler:options:customerror:)
+/// - Use timeout(_:scheduler:options:customError:) to terminate a publisher if an element isn’t delivered within a timeout interval you specify.
+final class TimeoutTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithTimeoutOperatorWithSuccess() {
+        let expectation = XCTestExpectation(description: "Testing timeout-with-success with time strategy operator")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.2, "Hel"),
+            (0.5, "Hello"),
+            (4.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 4.0 seconds.
+            (4.1, "Hello Wo"),
+            (4.2, "Hello Wor"),
+            (4.4, "Hello Worl"),
+            (4.5, "Hello World")
+          ]
+
+        let continuousPublisher = PassthroughSubject<String, Never>()
+        let timeoutPublisher = continuousPublisher.timeout(.seconds(2.0), scheduler: DispatchQueue.main, options: nil, customError: nil) // Timeout after 2 seconds
+
+        var isContinuousPublisherFinishedCalled = false
+        var receivedValues: [String] = []
+
+        continuousPublisher.sink { completion in
+            switch completion {
+            case .finished:
+                isContinuousPublisherFinishedCalled = true
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("continuousPublisher : \(value)")
+        }
+        .store(in: &cancellables)
+
+        timeoutPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            print("timeoutPublisher : \(value)")
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending continuousPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                continuousPublisher.send(value)
+            }
+        }
+
+        /*
+         0.0: continuousPublisher : H
+         0.0: timeoutPublisher : H // 👀
+         0.2: continuousPublisher : Hel
+         0.2: timeoutPublisher : Hel // 👀
+         0.5: continuousPublisher : Hello
+         0.5: timeoutPublisher : Hello // 👀
+         4.0: continuousPublisher : Hello W // TimeOut is already kicks-in with success because difference b/w (4.0 - 0.5) > 2 seconds and no longer accepting new values
+         4.1: continuousPublisher : Hello Wo
+         4.2: continuousPublisher : Hello Wor
+         4.4: continuousPublisher : Hello Worl
+         4.5: continuousPublisher : Hello World
+         */
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for continuousPublisher
+            continuousPublisher.send(completion: .finished)
+
+            // Ensuring that only received all values before timeout, instead of all continuous values after timeout
+            XCTAssertEqual(receivedValues, ["H", "Hel", "Hello"])
+
+            XCTAssertTrue(isContinuousPublisherFinishedCalled) // continuousPublisher is finished
+            XCTAssertTrue(self.isFinishedCalled) // timeoutPublisher is also finished
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testPublisherWithTimeoutOperatorWithError() {
+        let expectation = XCTestExpectation(description: "Testing timeout-with-error with time strategy operator")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.2, "Hel"),
+            (0.5, "Hello"),
+            (4.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 4.0 seconds.
+            (4.1, "Hello Wo"),
+            (4.2, "Hello Wor"),
+            (4.4, "Hello Worl"),
+            (4.5, "Hello World")
+          ]
+
+        let continuousPublisher = PassthroughSubject<String, Never>()
+        let error = ApiError(code: .notFound)
+        let timeoutPublisher = continuousPublisher
+            .setFailureType(to: ApiError.self)
+            .timeout(.seconds(2.0), scheduler: DispatchQueue.main, options: nil, customError: { error } ) // Timeout after 2 seconds with ApiError
+
+        var isContinuousPublisherFinishedCalled = false
+        var receivedValues: [String] = []
+        var receivedError: ApiError?
+
+        continuousPublisher.sink { completion in
+            switch completion {
+            case .finished:
+                isContinuousPublisherFinishedCalled = true
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("continuousPublisher : \(value)")
+        }
+        .store(in: &cancellables)
+
+        timeoutPublisher
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                receivedError = error
+            }
+        } receiveValue: { value in
+            print("timeoutPublisher : \(value)")
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Sending continuousPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                continuousPublisher.send(value)
+            }
+        }
+
+        /*
+         0.0: continuousPublisher : H
+         0.0: timeoutPublisher : H // 👀
+         0.2: continuousPublisher : Hel
+         0.2: timeoutPublisher : Hel // 👀
+         0.5: continuousPublisher : Hello
+         0.5: timeoutPublisher : Hello // 👀
+         4.0: continuousPublisher : Hello W // TimeOut is already kicks-in with ERROR because difference b/w (4.0 - 0.5) > 2 seconds and no longer accepting new values
+         4.1: continuousPublisher : Hello Wo
+         4.2: continuousPublisher : Hello Wor
+         4.4: continuousPublisher : Hello Worl
+         4.5: continuousPublisher : Hello World
+         */
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for continuousPublisher
+            continuousPublisher.send(completion: .finished)
+
+            // Ensuring that only received all values before timeout, instead of all continuous values after timeout
+            XCTAssertEqual(receivedValues, ["H", "Hel", "Hello"])
+
+            XCTAssertTrue(isContinuousPublisherFinishedCalled) // continuousPublisher is finished
+            XCTAssertFalse(self.isFinishedCalled) // timeoutPublisher finished is not called because it got timeout with ERROR
+            XCTAssertEqual(receivedError?.code, .notFound) // timeoutPublisher finished with correct ERROR
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
     - [x] Holding off events
       - `debounce(for:scheduler:options:)` https://github.com/crazymanish/what-matters-most/pull/105
       - `throttle(for:scheduler:latest:)` https://github.com/crazymanish/what-matters-most/pull/106
-    - [ ] Timing out
+    - [x] Timing out https://github.com/crazymanish/what-matters-most/pull/107
     - [ ] Measuring time
     - [ ] Practices
 - [ ] Sequence Operators


### PR DESCRIPTION
### Context
- Close ticket: #29 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Operators:: Time-manipulation Operators: Time out` 
- `timeout(_:scheduler:options:customError:)` Terminates publishing if the upstream publisher exceeds the specified time interval without producing an element.
- https://developer.apple.com/documentation/combine/publishers/reduce/timeout(_:scheduler:options:customerror:)
------------------
- Use timeout(_:scheduler:options:customError:) to terminate a publisher if an element isn’t delivered within a timeout interval you specify.