### PR TITLE
OR-5267 Operators:: Time-manipulation Operators: Measuring time

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		96DACA632A63F942004404AE /* DebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA622A63F942004404AE /* DebounceTests.swift */; };
 		96DACA652A640249004404AE /* ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA642A640249004404AE /* ThrottleTests.swift */; };
 		96DACA672A640D37004404AE /* TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA662A640D37004404AE /* TimeoutTests.swift */; };
+		96DACA692A64190F004404AE /* MeasureTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA682A64190F004404AE /* MeasureTimeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,6 +140,7 @@
 		96DACA622A63F942004404AE /* DebounceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTests.swift; sourceTree = "<group>"; };
 		96DACA642A640249004404AE /* ThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottleTests.swift; sourceTree = "<group>"; };
 		96DACA662A640D37004404AE /* TimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeoutTests.swift; sourceTree = "<group>"; };
+		96DACA682A64190F004404AE /* MeasureTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureTimeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -370,6 +372,7 @@
 				96DACA622A63F942004404AE /* DebounceTests.swift */,
 				96DACA642A640249004404AE /* ThrottleTests.swift */,
 				96DACA662A640D37004404AE /* TimeoutTests.swift */,
+				96DACA682A64190F004404AE /* MeasureTimeTests.swift */,
 			);
 			path = TimeManipulationOperators;
 			sourceTree = "<group>";
@@ -546,6 +549,7 @@
 				9631D29E29DB503900A9D790 /* URLSessionTests.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9631D2A029DBC51600A9D790 /* UserDefaultTests.swift in Sources */,
+				96DACA692A64190F004404AE /* MeasureTimeTests.swift in Sources */,
 				96DACA632A63F942004404AE /* DebounceTests.swift in Sources */,
 				9631D2C429DD161500A9D790 /* URLSession+Decodable.swift in Sources */,
 				9631D28029D6242700A9D790 /* RecordTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/MeasureTimeTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/TimeManipulationOperators/MeasureTimeTests.swift
@@ -1,0 +1,86 @@
+//
+//  MeasureTimeTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/07/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/// - `measureInterval(using:options:)` Measures and emits the time interval between events received from an upstream publisher.
+/// - https://developer.apple.com/documentation/combine/publishers/reduce/measureinterval(using:options:)
+/// - Use measureInterval(using:options:) to measure the time between events delivered from an upstream publisher.
+final class MeasureTimeTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMeasureTimeOperator() {
+        let expectation = XCTestExpectation(description: "Testing measure time strategy operator")
+
+        let typingHelloWorld: [(TimeInterval, String)] = [
+            (0.0, "H"),
+            (0.2, "Hel"),
+            (0.5, "Hello"),
+            (4.0, "Hello W"), // The simulated user starts typing at 0.0 seconds, pauses after 0.6 seconds, and resumes typing at 4.0 seconds.
+            (4.1, "Hello Wo"),
+            (4.2, "Hello Wor"),
+            (4.4, "Hello Worl"),
+            (4.5, "Hello World")
+          ]
+
+        let typingHelloWorldPublisher = PassthroughSubject<String, Never>()
+        var receivedValues: [String] = []
+
+        typingHelloWorldPublisher
+            .measureInterval(using: RunLoop.main)
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+
+                expectation.fulfill()
+            }
+        } receiveValue: { value in
+            print("RunLoop.SchedulerTimeType.Stride : \(value)")
+
+            let timeInterval = String(format: "%.2f", value.magnitude) // Double(value.magnitude) / 1_000_000_000.0
+            receivedValues.append(timeInterval)
+        }
+        .store(in: &cancellables)
+
+        // Sending typingHelloWorldPublisher values after continuous TimeInterval
+        for (key, value) in typingHelloWorld {
+            DispatchQueue.main.asyncAfter(deadline: .now() + key) {
+                typingHelloWorldPublisher.send(value)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            // Sending finished for typingHelloWorldPublisher
+            typingHelloWorldPublisher.send(completion: .finished)
+
+            // Time interval of each received values
+            XCTAssertEqual(receivedValues, ["0.00", "0.21", "0.32", "3.54", "0.10", "0.10", "0.20", "0.10"])
+
+            XCTAssertTrue(self.isFinishedCalled) // typingHelloWorldPublisher is also finished
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
       - `debounce(for:scheduler:options:)` https://github.com/crazymanish/what-matters-most/pull/105
       - `throttle(for:scheduler:latest:)` https://github.com/crazymanish/what-matters-most/pull/106
     - [x] Timing out https://github.com/crazymanish/what-matters-most/pull/107
-    - [ ] Measuring time
+    - [x] Measuring time https://github.com/crazymanish/what-matters-most/pull/108
     - [ ] Practices
 - [ ] Sequence Operators
     - [ ] Finding values


### PR DESCRIPTION
### Context
- Close ticket: #30 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

### In this PR
- `Operators:: Time-manipulation Operators: Measuring time` 
- `measureInterval(using:options:)` Measures and emits the time interval between events received from an upstream publisher.
- https://developer.apple.com/documentation/combine/publishers/reduce/measureinterval(using:options:)
------------------
- Use measureInterval(using:options:) to measure the time between events delivered from an upstream publisher.