### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `min()`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */; };
 		96AC4A342A5FD35400B2042E /* MergeWithTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A332A5FD35400B2042E /* MergeWithTests.swift */; };
 		96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A452A60081500B2042E /* CombineLatestTests.swift */; };
+		96B40BD02A7E653A001D06AF /* SequenceFindingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B40BCF2A7E653A001D06AF /* SequenceFindingValuesTests.swift */; };
 		96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA1B2A6019F2004404AE /* ZipTests.swift */; };
 		96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */; };
 		96DACA612A631884004404AE /* CollectByTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DACA602A631884004404AE /* CollectByTimeTests.swift */; };
@@ -134,6 +135,7 @@
 		96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatestTests.swift; sourceTree = "<group>"; };
 		96AC4A332A5FD35400B2042E /* MergeWithTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
 		96AC4A452A60081500B2042E /* CombineLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatestTests.swift; sourceTree = "<group>"; };
+		96B40BCF2A7E653A001D06AF /* SequenceFindingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceFindingValuesTests.swift; sourceTree = "<group>"; };
 		96DACA1B2A6019F2004404AE /* ZipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipTests.swift; sourceTree = "<group>"; };
 		96DACA5E2A630C5E004404AE /* ShiftingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftingTimeTests.swift; sourceTree = "<group>"; };
 		96DACA602A631884004404AE /* CollectByTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectByTimeTests.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 			children = (
 				96AC4A2C2A5FB45100B2042E /* CombiningOperators */,
 				9612D6B32A5AFA46007CBD1A /* FilteringOperators */,
+				96B40BCE2A7E6504001D06AF /* SequenceOperators */,
 				96DACA5D2A62D42A004404AE /* TimeManipulationOperators */,
 				96321F032A5AA2F500C60D8A /* TransformingOperators */,
 			);
@@ -362,6 +365,14 @@
 				96DACA1B2A6019F2004404AE /* ZipTests.swift */,
 			);
 			path = CombiningOperators;
+			sourceTree = "<group>";
+		};
+		96B40BCE2A7E6504001D06AF /* SequenceOperators */ = {
+			isa = PBXGroup;
+			children = (
+				96B40BCF2A7E653A001D06AF /* SequenceFindingValuesTests.swift */,
+			);
+			path = SequenceOperators;
 			sourceTree = "<group>";
 		};
 		96DACA5D2A62D42A004404AE /* TimeManipulationOperators */ = {
@@ -539,6 +550,7 @@
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
 				966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
+				96B40BD02A7E653A001D06AF /* SequenceFindingValuesTests.swift in Sources */,
 				96DACA1C2A6019F2004404AE /* ZipTests.swift in Sources */,
 				966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */,
 				9667847D2A5B27A800398D70 /* FindingValuesTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
@@ -1,0 +1,64 @@
+//
+//  SequenceFindingValuesTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 05/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+ Sequence operators
+ - Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
+ - Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!
+
+ Finding values
+ - This file consists of operators that locate specific values the publisher emits based on different criteria.
+ - These are similar to the collection methods in the Swift standard library.
+
+ - `min()` Publishes the minimum value received from the upstream publisher, after it finishes.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/min()
+ */
+final class SequenceFindingValuesTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMinOperator() {
+        // Given: Publisher
+        let publisher = [15, -1, 10, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .min() // Returns the minimum value, after upstream will finish!
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [-1])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@
     - [x] Measuring time https://github.com/crazymanish/what-matters-most/pull/108
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/103, https://github.com/crazymanish/what-matters-most/pull/104, https://github.com/crazymanish/what-matters-most/pull/105, https://github.com/crazymanish/what-matters-most/pull/106, https://github.com/crazymanish/what-matters-most/pull/107, https://github.com/crazymanish/what-matters-most/pull/108, https://github.com/crazymanish/what-matters-most/pull/109
 - [ ] Sequence Operators
-    - [ ] Finding values
+    - [x] Finding values
+      - `min()` https://github.com/crazymanish/what-matters-most/pull/110
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: min()` 
- `min()` Publishes the minimum value received from the upstream publisher, after it finishes.
- https://developer.apple.com/documentation/combine/publishers/reduce/min()