### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `max()`

### DIFF
--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
@@ -24,6 +24,9 @@ import XCTest
  - `min(by:)` Publishes the minimum value received from the upstream publisher, after it finishes.
  - A closure that receives two elements and returns true if they’re in increasing order.
  - https://developer.apple.com/documentation/combine/publishers/reduce/min(by:)
+
+ - `max()` Publishes the maximum value received from the upstream publisher, after it finishes.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/max()
  */
 final class SequenceFindingValuesTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -97,5 +100,28 @@ final class SequenceFindingValuesTests: XCTestCase {
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
         XCTAssertEqual(receivedValues, ["ab"])
+    }
+
+    func testPublisherWithMaxOperator() {
+        // Given: Publisher
+        let publisher = [5, -1, 10, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .max() // Returns the maximum value, after upstream will finish!
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [10])
     }
 }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
     - [x] Finding values
       - `min()` https://github.com/crazymanish/what-matters-most/pull/110
       - `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
+      - `max()` https://github.com/crazymanish/what-matters-most/pull/111
     - [ ] Query the publisher
     - [ ] Practices
   

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
     - [x] Finding values
       - `min()` https://github.com/crazymanish/what-matters-most/pull/110
       - `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
-      - `max()` https://github.com/crazymanish/what-matters-most/pull/111
+      - `max()` https://github.com/crazymanish/what-matters-most/pull/112
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: max()`
- `max()` Publishes the maximum value received from the upstream publisher, after it finishes.
- https://developer.apple.com/documentation/combine/publishers/reduce/max()