### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `max(by:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
       - `min()` https://github.com/crazymanish/what-matters-most/pull/110
       - `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
       - `max()` https://github.com/crazymanish/what-matters-most/pull/112
+      - `max(by:)` https://github.com/crazymanish/what-matters-most/pull/113
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: max(by:)`
- `max(by:)` Publishes the maximum value received from the upstream publisher, using the provided ordering closure.
- A closure that receives two elements and returns true if they’re in increasing order.
- https://developer.apple.com/documentation/combine/publishers/reduce/max(by:)