### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `first()`

### DIFF
--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
@@ -31,6 +31,9 @@ import XCTest
  - `max(by:)` Publishes the maximum value received from the upstream publisher, using the provided ordering closure.
  - A closure that receives two elements and returns true if they’re in increasing order.
  - https://developer.apple.com/documentation/combine/publishers/reduce/max(by:)
+
+ - `first()` Publishes the first element of a stream, then finishes.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/first()
  */
 final class SequenceFindingValuesTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -160,5 +163,28 @@ final class SequenceFindingValuesTests: XCTestCase {
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
         XCTAssertEqual(receivedValues, ["hello world"])
+    }
+
+    func testPublisherWithFirstOperator() {
+        // Given: Publisher
+        let publisher = [15, -1, 10, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .first() // `first()` publish just the first element from an upstream publisher, then finish normally.
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [15])
     }
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
       - `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
       - `max()` https://github.com/crazymanish/what-matters-most/pull/112
       - `max(by:)` https://github.com/crazymanish/what-matters-most/pull/113
+      - `first()` https://github.com/crazymanish/what-matters-most/pull/114
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: first()`
- `first()` Publishes the first element of a stream, then finishes.
- https://developer.apple.com/documentation/combine/publishers/reduce/first()