### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `last(where:)`

### DIFF
--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
@@ -41,6 +41,10 @@ import XCTest
 
  - `last()` Publishes the last element of a stream, after the stream finishes.
  - https://developer.apple.com/documentation/combine/publishers/reduce/last()
+
+ - `last(where:)` Publishes the last element of a stream that satisfies a predicate closure, after upstream finishes.
+ - A closure that takes an element as its parameter and returns a Boolean value that indicates whether to publish the element.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/last(where:)
  */
 final class SequenceFindingValuesTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -239,5 +243,28 @@ final class SequenceFindingValuesTests: XCTestCase {
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
         XCTAssertEqual(receivedValues, [5])
+    }
+
+    func testPublisherWithLastWhereOperator() {
+        // Given: Publisher
+        let publisher = [15, -1, -10, 10, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .last { $0 < 0 } // `last(where:)` publish only the last element of a stream that satisfies a predicate closure, after upstream finishes.
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [-10])
     }
 }

--- a/README.md
+++ b/README.md
@@ -108,13 +108,10 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/103, https://github.com/crazymanish/what-matters-most/pull/104, https://github.com/crazymanish/what-matters-most/pull/105, https://github.com/crazymanish/what-matters-most/pull/106, https://github.com/crazymanish/what-matters-most/pull/107, https://github.com/crazymanish/what-matters-most/pull/108, https://github.com/crazymanish/what-matters-most/pull/109
 - [ ] Sequence Operators
     - [x] Finding values
-      - `min()` https://github.com/crazymanish/what-matters-most/pull/110
-      - `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
-      - `max()` https://github.com/crazymanish/what-matters-most/pull/112
-      - `max(by:)` https://github.com/crazymanish/what-matters-most/pull/113
-      - `first()` https://github.com/crazymanish/what-matters-most/pull/114
-      - `first(where:)` https://github.com/crazymanish/what-matters-most/pull/115
-      - `last()` https://github.com/crazymanish/what-matters-most/pull/116
+      - `min()` https://github.com/crazymanish/what-matters-most/pull/110 `min(by:)` https://github.com/crazymanish/what-matters-most/pull/111
+      - `max()` https://github.com/crazymanish/what-matters-most/pull/112 `max(by:)` https://github.com/crazymanish/what-matters-most/pull/113
+      - `first()` https://github.com/crazymanish/what-matters-most/pull/114 `first(where:)` https://github.com/crazymanish/what-matters-most/pull/115
+      - `last()` https://github.com/crazymanish/what-matters-most/pull/116 `last(where:)` https://github.com/crazymanish/what-matters-most/pull/117
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: last(where:)`
- `last(where:)` Publishes the last element of a stream that satisfies a predicate closure, after upstream finishes.
- A closure that takes an element as its parameter and returns a Boolean value that indicates whether to publish the element.
- https://developer.apple.com/documentation/combine/publishers/reduce/last(where:)