### PR TITLE
OR-5269 Operators:: Sequence Operators:: Finding values:: `output(in:)`

### DIFF
--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceFindingValuesTests.swift
@@ -49,6 +49,10 @@ import XCTest
  - `output(at:)` Publishes a specific element, indicated by its index in the sequence of published elements.
  - index param: The index that indicates the element to publish.
  - https://developer.apple.com/documentation/combine/publishers/reduce/output(at:)
+
+ - `output(in:)` Publishes elements specified by their range in the sequence of published elements.
+ - range param: A range that indicates which elements to publish.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/output(in:)
  */
 final class SequenceFindingValuesTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -293,5 +297,28 @@ final class SequenceFindingValuesTests: XCTestCase {
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
         XCTAssertEqual(receivedValues, [-10])
+    }
+
+    func testPublisherWithOutputInOperator() {
+        // Given: Publisher
+        let publisher = [15, -1, -10, 10, 5, 8].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .output(in: 2...4) // Elements b/w 2nd to 4th index.
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [-10, 10, 5])
     }
 }

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@
       - `max()` https://github.com/crazymanish/what-matters-most/pull/112 `max(by:)` https://github.com/crazymanish/what-matters-most/pull/113
       - `first()` https://github.com/crazymanish/what-matters-most/pull/114 `first(where:)` https://github.com/crazymanish/what-matters-most/pull/115
       - `last()` https://github.com/crazymanish/what-matters-most/pull/116 `last(where:)` https://github.com/crazymanish/what-matters-most/pull/117
-      - `output(at:)` https://github.com/crazymanish/what-matters-most/pull/118
+      - `output(at:)` https://github.com/crazymanish/what-matters-most/pull/118 `output(in:)` https://github.com/crazymanish/what-matters-most/pull/119
     - [ ] Query the publisher
     - [ ] Practices
   


### PR DESCRIPTION
### Context
- Close ticket: #32 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Finding values
- This file consists of operators that locate specific values the publisher emits based on different criteria.
- These are similar to the collection methods in the Swift standard library.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: output(in:)`
- `output(in:)` Publishes elements specified by their range in the sequence of published elements.
- range param: A range that indicates which elements to publish.
- https://developer.apple.com/documentation/combine/publishers/reduce/output(in:)