### PR TITLE
OR-5269 Operators:: Sequence Operators:: Querying values:: `count()`

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A429D365D100CB89C8 /* EmptyTests.swift */; };
 		9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A629D369A600CB89C8 /* ApiError.swift */; };
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
+		96442C5C2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */; };
 		966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */; };
 		966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784782A5B057F00398D70 /* CompactMapTests.swift */; };
 		9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */; };
@@ -122,6 +123,7 @@
 		9642B7A429D365D100CB89C8 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		9642B7A629D369A600CB89C8 /* ApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiError.swift; sourceTree = "<group>"; };
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
+		96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceQueryingValuesTests.swift; sourceTree = "<group>"; };
 		966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDuplicateTests.swift; sourceTree = "<group>"; };
 		966784782A5B057F00398D70 /* CompactMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMapTests.swift; sourceTree = "<group>"; };
 		9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputTests.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 			isa = PBXGroup;
 			children = (
 				96B40BCF2A7E653A001D06AF /* SequenceFindingValuesTests.swift */,
+				96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */,
 			);
 			path = SequenceOperators;
 			sourceTree = "<group>";
@@ -571,6 +574,7 @@
 				96DACA652A640249004404AE /* ThrottleTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */,
+				96442C5C2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift in Sources */,
 				9641203F2A5B38AF00A69216 /* LimitingValuesTests.swift in Sources */,
 				9667847F2A5B302E00398D70 /* DroppingValuesTests.swift in Sources */,
 				96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceQueryingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceQueryingValuesTests.swift
@@ -1,0 +1,64 @@
+//
+//  SequenceQueryingValuesTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 06/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+ Sequence operators
+ - Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
+ - Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!
+
+ Querying the publisher
+ - The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
+ - Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.
+
+ - `count()` Publishes the number of elements received from the upstream publisher.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/count()
+ */
+final class SequenceQueryingValuesTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithMinOperator() {
+        // Given: Publisher
+        let publisher = [15, -1, 10, 5].publisher
+        var receivedValues: [Int] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .count() // Returns the count value, after upstream will finish!
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, [4])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@
       - `first()` https://github.com/crazymanish/what-matters-most/pull/114 `first(where:)` https://github.com/crazymanish/what-matters-most/pull/115
       - `last()` https://github.com/crazymanish/what-matters-most/pull/116 `last(where:)` https://github.com/crazymanish/what-matters-most/pull/117
       - `output(at:)` https://github.com/crazymanish/what-matters-most/pull/118 `output(in:)` https://github.com/crazymanish/what-matters-most/pull/119
-    - [ ] Query the publisher
+    - [x] Query the publisher
+      - `count()` https://github.com/crazymanish/what-matters-most/pull/120
     - [ ] Practices
   
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #33 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Querying values
- The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
- Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: count()`
- `count()` Publishes the number of elements received from the upstream publisher.
- https://developer.apple.com/documentation/combine/publishers/reduce/count()