### PR TITLE
OR-5269 Operators:: Sequence Operators:: Querying values:: `contains(_:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
       - `output(at:)` https://github.com/crazymanish/what-matters-most/pull/118 `output(in:)` https://github.com/crazymanish/what-matters-most/pull/119
     - [x] Query the publisher
       - `count()` https://github.com/crazymanish/what-matters-most/pull/120
+      - `contains(_:)` https://github.com/crazymanish/what-matters-most/pull/121
     - [ ] Practices
   
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #33 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Querying values
- The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
- Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: contains(_:)`
- `contains(_:)` Publishes a Boolean value upon receiving an element equal to the argument.
- The contains publisher consumes all received elements until the upstream publisher produces a matching element. Upon finding the first match, it emits true and finishes normally. If the upstream finishes normally without producing a matching element, this publisher emits false and finishes.
- https://developer.apple.com/documentation/combine/publishers/reduce/contains(_:)