### PR TITLE
OR-5269 Operators:: Sequence Operators:: Querying values:: `contains(where:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
       - `output(at:)` https://github.com/crazymanish/what-matters-most/pull/118 `output(in:)` https://github.com/crazymanish/what-matters-most/pull/119
     - [x] Query the publisher
       - `count()` https://github.com/crazymanish/what-matters-most/pull/120
-      - `contains(_:)` https://github.com/crazymanish/what-matters-most/pull/121
+      - `contains(_:)` https://github.com/crazymanish/what-matters-most/pull/121 `contains(where:)` https://github.com/crazymanish/what-matters-most/pull/122
     - [ ] Practices
   
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #33 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Querying values
- The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
- Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: contains(where:)`
- `contains(where:)` Publishes a Boolean value upon receiving an element that satisfies the predicate closure.
- Param: A closure that takes an element as its parameter and returns a Boolean value that indicates whether the element satisfies the closure’s comparison logic.
- Use contains(where:) to find the first element in an upstream that satisfies the closure you provide. This operator consumes elements produced from the upstream publisher until the upstream publisher produces a matching element.
- This operator is useful when the upstream publisher produces elements that **don’t conform to Equatable**.
- https://developer.apple.com/documentation/combine/publishers/reduce/contains(where:)