### PR TITLE
OR-5270 Operators:: Sequence Operators:: Querying values:: `allSatisfy(_:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
     - [x] Query the publisher
       - `count()` https://github.com/crazymanish/what-matters-most/pull/120
       - `contains(_:)` https://github.com/crazymanish/what-matters-most/pull/121 `contains(where:)` https://github.com/crazymanish/what-matters-most/pull/122
+      - `allSatisfy(_:)` https://github.com/crazymanish/what-matters-most/pull/123
     - [ ] Practices
   
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #33 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Querying values
- The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
- Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: allSatisfy(_:)`
- `allSatisfy(_:)` Publishes a single Boolean value that indicates whether all received elements pass a given predicate.
- Param: A closure that evaluates each received element. Return true to continue, or false to cancel the upstream and complete.
- Use the allSatisfy(_:) operator to determine if all elements in a stream satisfy a criteria you provide.
- When this publisher receives an element, it runs the predicate against the element. If the predicate returns false, the publisher produces a false value and finishes.
- If the upstream publisher finishes normally, this publisher produces a true value and finishes.
- https://developer.apple.com/documentation/combine/publishers/reduce/allsatisfy(_:)