### PR TITLE
OR-5270 Operators:: Sequence Operators:: Querying values:: `reduce(_:_:)`

### DIFF
--- a/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceQueryingValuesTests.swift
+++ b/CombineDemo/CombineDemoTests/Operators/SequenceOperators/SequenceQueryingValuesTests.swift
@@ -37,6 +37,12 @@ import XCTest
  - When this publisher receives an element, it runs the predicate against the element. If the predicate returns false, the publisher produces a false value and finishes.
  - If the upstream publisher finishes normally, this publisher produces a true value and finishes.
  - https://developer.apple.com/documentation/combine/publishers/reduce/allsatisfy(_:)
+
+ - `reduce(_:_:)` Applies a closure that collects each element of a stream and publishes a final result upon completion.
+ - Param: initialResult:: The value that the closure receives the first time it’s called.
+ - Param: nextPartialResult:: A closure that produces a new value by taking the previously-accumulated value and the next element it receives from the upstream publisher.
+ - Use reduce(_:_:) to collect a stream of elements and produce an accumulated value based on a closure you provide.
+ - https://developer.apple.com/documentation/combine/publishers/reduce/reduce(_:_:)
  */
 final class SequenceQueryingValuesTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -149,5 +155,30 @@ final class SequenceQueryingValuesTests: XCTestCase {
         // Then: Receiving correct value
         XCTAssertTrue(isFinishedCalled)
         XCTAssertEqual(receivedValues, [true])
+    }
+
+    func testPublisherWithReduceOperator() {
+        // Given: Publisher
+        let publisher = ["Hel", "lo", " ", "Wor", "ld", "!"].publisher
+        var receivedValues: [String] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .reduce("This is ") { accumulator, value in // collects all the string values it receives from its upstream publisher
+                accumulator+value
+            }
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+                }
+            } receiveValue: { value in
+                receivedValues.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValues, ["This is Hello World!"])
     }
 }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
       - `count()` https://github.com/crazymanish/what-matters-most/pull/120
       - `contains(_:)` https://github.com/crazymanish/what-matters-most/pull/121 `contains(where:)` https://github.com/crazymanish/what-matters-most/pull/122
       - `allSatisfy(_:)` https://github.com/crazymanish/what-matters-most/pull/123
+      - `reduce(_:_:)` https://github.com/crazymanish/what-matters-most/pull/124 
     - [ ] Practices
   
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #33 

### Operators are publishers
- In Combine, methods that perform an operation on values coming from a publisher are called operators.
- Each Combine operator actually returns a publisher. Generally speaking, that publisher receives the upstream values, manipulates the data, and then sends that data downstream. 

#### Sequence operators
- Sequence operators are easiest to understand when you realize that publishers are just sequences themselves.
- Sequence operators work with the `collection of a publisher’s values`, much like an array or set — which, of course, are just finite sequences!

#### Querying values
- The following operators also deal with the entire set of values emitted by a publisher, but they don't produce any specific value that it emits.
- Instead, these operators emit a different value representing some query on the publisher as a whole. A good example of this is the count operator.

### In this PR
- `Operators:: Sequence Operators:: Finding values:: reduce(_:_:)`
- `reduce(_:_:)` Applies a closure that collects each element of a stream and publishes a final result upon completion.
- Param: initialResult:: The value that the closure receives the first time it’s called.
- Param: nextPartialResult:: A closure that produces a new value by taking the previously-accumulated value and the next element it receives from the upstream publisher.
- Use reduce(_:_:) to collect a stream of elements and produce an accumulated value based on a closure you provide.
- https://developer.apple.com/documentation/combine/publishers/reduce/reduce(_:_:)