### PR TITLE
OR-5272 Networking:: URLSession extension

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9609A73A2A87F6DC00383991 /* NetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A7392A87F6DC00383991 /* NetworkingTests.swift */; };
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
@@ -84,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9609A7392A87F6DC00383991 /* NetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingTests.swift; sourceTree = "<group>"; };
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
@@ -172,6 +174,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9609A7382A87F6A900383991 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				9609A7392A87F6DC00383991 /* NetworkingTests.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
 		9612D6B32A5AFA46007CBD1A /* FilteringOperators */ = {
 			isa = PBXGroup;
 			children = (
@@ -295,6 +305,7 @@
 			isa = PBXGroup;
 			children = (
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
+				9609A7382A87F6A900383991 /* Networking */,
 				96321F022A5AA2E100C60D8A /* Operators */,
 				9642B77B29D2144800CB89C8 /* Publishers */,
 				967AF3A72A485BF700AB60CA /* Subject */,
@@ -565,6 +576,7 @@
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9631D2A029DBC51600A9D790 /* UserDefaultTests.swift in Sources */,
 				96DACA692A64190F004404AE /* MeasureTimeTests.swift in Sources */,
+				9609A73A2A87F6DC00383991 /* NetworkingTests.swift in Sources */,
 				96DACA632A63F942004404AE /* DebounceTests.swift in Sources */,
 				9631D2C429DD161500A9D790 /* URLSession+Decodable.swift in Sources */,
 				9631D28029D6242700A9D790 /* RecordTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Networking/NetworkingTests.swift
+++ b/CombineDemo/CombineDemoTests/Networking/NetworkingTests.swift
@@ -1,0 +1,64 @@
+//
+//  NetworkingTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 12/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+final class NetworkingTests: XCTestCase {
+    var urlSession: URLSession!
+    var publisher: URLSession.DataTaskPublisher!
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedError: Error?
+
+    override func setUp() {
+        super.setUp()
+
+        let apiURL = URL(string: "https://api.github.com/users/crazymanish")
+        urlSession = URLSession.shared
+        publisher = urlSession.dataTaskPublisher(for: apiURL!)
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        urlSession = nil
+        publisher = nil
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedError = nil
+
+        super.tearDown()
+    }
+
+    func testURLSessionPublisher() {
+        let expectation = XCTestExpectation(description: "Fetching GitHub user info")
+
+        publisher.sink { [weak self] completion in
+            guard let self else { return }
+
+            switch completion {
+            case .finished:
+                self.isFinishedCalled = true
+            case .failure(let error):
+                self.receivedError = error
+            }
+
+            XCTAssertTrue(self.isFinishedCalled)
+            XCTAssertNil(self.receivedError)
+            expectation.fulfill()
+        } receiveValue: { apiResponse in
+            let jsonResponse = try? JSONSerialization.jsonObject(with: apiResponse.data, options: []) as? [String: Any]
+            XCTAssertEqual(jsonResponse?["login"] as? String, "crazymanish")
+            XCTAssertEqual(jsonResponse?["name"] as? String, "Manish Rathi")
+        }
+        .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@
 #### Section3: Combine in action
 
 - [ ] Networking
-    - [ ] URLSession extensions
+    - [x] URLSession extensions https://github.com/crazymanish/what-matters-most/pull/126
     - [ ] Codable support
     - [ ] Publishing network data
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #35 

### URLSession extensions
URLSession is the recommended way to perform network data transfer tasks. It offers a modern asynchronous API with powerful configuration options and fully transparent backgrounding support. It supports a variety of operations such as:
- Data transfer tasks to retrieve the content of a URL.
- Download tasks to retrieve the content of a URL and save it to a file.
- Upload tasks to upload files and data to a URL.
- Stream tasks to stream data between two parties.
- Websocket tasks to connect to websockets.

#### Combine extension
- Out of these, **only the first one**, data transfer tasks, exposes a Combine publisher. 
- Combine handles these tasks using a single API with two variants, 
  - taking a URLRequest (Example PR: https://github.com/crazymanish/what-matters-most/pull/68)
  - or just a URL. (in this PR)

### In this PR
- Fetching API data using just a URL.