### PR TITLE
OR-5273 Networking:: Codable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 
 - [ ] Networking
     - [x] URLSession extensions https://github.com/crazymanish/what-matters-most/pull/126
-    - [ ] Codable support
+    - [x] Codable support https://github.com/crazymanish/what-matters-most/pull/126
     - [ ] Publishing network data
     - [ ] Practices
 - [ ] Debugging

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 
 - [ ] Networking
     - [x] URLSession extensions https://github.com/crazymanish/what-matters-most/pull/126
-    - [x] Codable support https://github.com/crazymanish/what-matters-most/pull/126
+    - [x] Codable support https://github.com/crazymanish/what-matters-most/pull/127
     - [ ] Publishing network data
     - [ ] Practices
 - [ ] Debugging


### PR DESCRIPTION
### Context
- Close ticket: #36 

### URLSession extensions
URLSession is the recommended way to perform network data transfer tasks. It offers a modern asynchronous API with powerful configuration options and fully transparent backgrounding support. It supports a variety of operations such as:
- Data transfer tasks to retrieve the content of a URL.
- Download tasks to retrieve the content of a URL and save it to a file.
- Upload tasks to upload files and data to a URL.
- Stream tasks to stream data between two parties.
- Websocket tasks to connect to websockets.

#### Combine extension
- Out of these, **only the first one**, data transfer tasks, exposes a Combine publisher. 
- Combine handles these tasks using a single API with two variants, 
  - taking a URLRequest (Example PR: https://github.com/crazymanish/what-matters-most/pull/68)
  - or just a URL. (in this PR)

### In this PR
- Fetching API data using just a URL **with codable**