### PR TITLE
OR-5274 Networking:: Publishing network data to multiple subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@
 - [ ] Networking
     - [x] URLSession extensions https://github.com/crazymanish/what-matters-most/pull/126
     - [x] Codable support https://github.com/crazymanish/what-matters-most/pull/127
-    - [ ] Publishing network data
+    - [x] Publishing network data https://github.com/crazymanish/what-matters-most/pull/128
     - [ ] Practices
 - [ ] Debugging
     - [ ] Printing events


### PR DESCRIPTION
### Context
- Close ticket: #37 

### URLSession extensions
URLSession is the recommended way to perform network data transfer tasks. It offers a modern asynchronous API with powerful configuration options and fully transparent backgrounding support. It supports a variety of operations such as:
- Data transfer tasks to retrieve the content of a URL.
- Download tasks to retrieve the content of a URL and save it to a file.
- Upload tasks to upload files and data to a URL.
- Stream tasks to stream data between two parties.
- Websocket tasks to connect to websockets.

#### Combine extension
- Out of these, **only the first one**, data transfer tasks, exposes a Combine publisher. 
- Combine handles these tasks using a single API with two variants, 
  - taking a URLRequest (Example PR: https://github.com/crazymanish/what-matters-most/pull/68)
  - or just a URL. (in this PR)

### In this PR
- Publishing network data to multiple subscribers

### Note:
- While **there‘s no operator** `to share a replay of a subscription` **with multiple subscribers**, 
- but, we can recreate this behavior using a ConnectablePublisher and the multicast operator.