### PR TITLE
OR-5276 Debugging:: Printing events

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9609A73A2A87F6DC00383991 /* NetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A7392A87F6DC00383991 /* NetworkingTests.swift */; };
+		9609A73D2A891B1700383991 /* PrintingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A73C2A891B1700383991 /* PrintingEventsTests.swift */; };
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
@@ -86,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		9609A7392A87F6DC00383991 /* NetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingTests.swift; sourceTree = "<group>"; };
+		9609A73C2A891B1700383991 /* PrintingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingEventsTests.swift; sourceTree = "<group>"; };
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
@@ -180,6 +182,14 @@
 				9609A7392A87F6DC00383991 /* NetworkingTests.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		9609A73B2A891AF500383991 /* Debugging */ = {
+			isa = PBXGroup;
+			children = (
+				9609A73C2A891B1700383991 /* PrintingEventsTests.swift */,
+			);
+			path = Debugging;
 			sourceTree = "<group>";
 		};
 		9612D6B32A5AFA46007CBD1A /* FilteringOperators */ = {
@@ -305,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
+				9609A73B2A891AF500383991 /* Debugging */,
 				9609A7382A87F6A900383991 /* Networking */,
 				96321F022A5AA2E100C60D8A /* Operators */,
 				9642B77B29D2144800CB89C8 /* Publishers */,
@@ -544,6 +555,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				96321F052A5AA32200C60D8A /* CollectTests.swift in Sources */,
+				9609A73D2A891B1700383991 /* PrintingEventsTests.swift in Sources */,
 				967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */,
 				9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */,
 				96DACA672A640D37004404AE /* TimeoutTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Debugging/PrintingEventsTests.swift
+++ b/CombineDemo/CombineDemoTests/Debugging/PrintingEventsTests.swift
@@ -1,0 +1,95 @@
+//
+//  PrintingEventsTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+- Understanding the event flow in asynchronous programs has always been a challenge.
+- It is particularly the case in the context of Combine, as chains of operators in a publisher may not all emit events at the same time.
+- Combine provides a few operators to help with debugging your reactive flows. Knowing them will help you troubleshoot puzzling situations.
+
+- `print(_:to:)` Prints log messages for all publishing events.
+- https://developer.apple.com/documentation/combine/publisher/print(_:to:)
+ */
+final class PrintingEventsTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+
+        super.tearDown()
+    }
+
+    func testPrintOperator() {
+        let publisher = (1...3).publisher
+
+        publisher
+            .print("Logged a debug message") // This is magical operator for debug (using prefix in logging-message)
+            .sink { _ in }
+            .store(in: &cancellables)
+
+        /*
+         // Prints:
+         //  Logged a debug message: receive subscription: (1...3)
+         //  Logged a debug message: request unlimited
+         //  Logged a debug message: receive value: (1)
+         //  Logged a debug message: receive value: (2)
+         //  Logged a debug message: receive value: (3)
+         //  Logged a debug message: receive finished
+         */
+    }
+
+    func testPrintOperatorWithTextOutputStream() {
+        let publisher = (1...3).publisher
+        let debugLogger = TimeStampDebugLogger()
+
+        publisher
+            .print("Logged a debug message", to: debugLogger) // Using prefix with custom TimeStamp debugger for print
+            .sink { _ in }
+            .store(in: &cancellables)
+
+        /*
+         // Prints:
+         //  +0.00010s: Logged a debug message: receive subscription: (1...3)
+         //  +0.00003s: Logged a debug message: request unlimited
+         //  +0.00001s: Logged a debug message: receive value: (1)
+         //  +0.00001s: Logged a debug message: receive value: (2)
+         //  +0.00001s: Logged a debug message: receive value: (3)
+         //  +0.00001s: Logged a debug message: receive finished
+         */
+    }
+}
+
+class TimeStampDebugLogger: TextOutputStream {
+    private var previousDate = Date()
+    private let formatter = NumberFormatter()
+
+    init() {
+        formatter.maximumFractionDigits = 5
+        formatter.minimumFractionDigits = 5
+    }
+
+    func write(_ string: String) {
+        let trimmedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedString.isEmpty else { return }
+
+        let nowDate = Date()
+        let formattedDate = formatter.string(for: nowDate.timeIntervalSince(previousDate))!
+        print("+\(formattedDate)s: \(trimmedString)")
+
+        previousDate = nowDate
+  }
+}

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@
     - [x] Publishing network data https://github.com/crazymanish/what-matters-most/pull/128
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/126, https://github.com/crazymanish/what-matters-most/pull/127, https://github.com/crazymanish/what-matters-most/pull/128, https://github.com/crazymanish/what-matters-most/pull/129
 - [ ] Debugging
-    - [ ] Printing events
+    - [x] Printing events https://github.com/crazymanish/what-matters-most/pull/130
     - [ ] Acting on events
     - [ ] Using debugger
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #39 

### Printing events
- Understanding the event flow in asynchronous programs has always been a challenge.
- It is particularly the case in the context of Combine, as chains of operators in a publisher may not all emit events at the same time.
- **Combine provides a few operators to help with debugging your reactive flows.** Knowing them will help you troubleshoot puzzling situations.
--------------------
- `print(_:to:)` Prints log messages for all publishing events.
- https://developer.apple.com/documentation/combine/publisher/print(_:to:)

### In this PR
- Using print-operator with a prefix
- Using print-operator with a prefix + custom logging