### PR TITLE
OR-5277 Debugging:: Handling events using different callbacks

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9609A73A2A87F6DC00383991 /* NetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A7392A87F6DC00383991 /* NetworkingTests.swift */; };
 		9609A73D2A891B1700383991 /* PrintingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A73C2A891B1700383991 /* PrintingEventsTests.swift */; };
+		9609A73F2A8923E800383991 /* HandlingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A73E2A8923E800383991 /* HandlingEventsTests.swift */; };
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
@@ -88,6 +89,7 @@
 /* Begin PBXFileReference section */
 		9609A7392A87F6DC00383991 /* NetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingTests.swift; sourceTree = "<group>"; };
 		9609A73C2A891B1700383991 /* PrintingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingEventsTests.swift; sourceTree = "<group>"; };
+		9609A73E2A8923E800383991 /* HandlingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlingEventsTests.swift; sourceTree = "<group>"; };
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 			isa = PBXGroup;
 			children = (
 				9609A73C2A891B1700383991 /* PrintingEventsTests.swift */,
+				9609A73E2A8923E800383991 /* HandlingEventsTests.swift */,
 			);
 			path = Debugging;
 			sourceTree = "<group>";
@@ -595,6 +598,7 @@
 				96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */,
 				9642B78029D2876200CB89C8 /* FutureTests.swift in Sources */,
 				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
+				9609A73F2A8923E800383991 /* HandlingEventsTests.swift in Sources */,
 				96DACA652A640249004404AE /* ThrottleTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Debugging/HandlingEventsTests.swift
+++ b/CombineDemo/CombineDemoTests/Debugging/HandlingEventsTests.swift
@@ -1,0 +1,68 @@
+//
+//  HandlingEventsTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+- Besides printing out information, it is often useful to perform actions upon specific events.
+- We call this performing side effects, as actions you take “on the side” don’t directly impact further publishers down the stream, but can have an effect like modifying an external variable.
+
+- `handleEvents(receiveSubscription:receiveOutput:receiveCompletion:receiveCancel:receiveRequest:)` Performs the specified closures when publisher events occur.
+  - receiveSubscription: An optional closure that executes when the publisher receives the subscription from the upstream publisher. This value defaults to nil.
+  - receiveOutput: An optional closure that executes when the publisher receives a value from the upstream publisher. This value defaults to nil.
+  - receiveCompletion: An optional closure that executes when the upstream publisher finishes normally or terminates with an error. This value defaults to nil.
+  - receiveCancel: An optional closure that executes when the downstream receiver cancels publishing. This value defaults to nil.
+  - receiveRequest: An optional closure that executes when the publisher receives a request for more elements. This value defaults to nil.
+- https://developer.apple.com/documentation/combine/publisher/handleevents(receivesubscription:receiveoutput:receivecompletion:receivecancel:receiverequest:)
+ */
+final class HandlingEventsTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+
+        super.tearDown()
+    }
+
+    func testHandleEventsOperator() {
+        let publisher = (1...3).publisher
+
+        publisher
+            .handleEvents(receiveSubscription: { subscription in
+                print("Subscription received: \(subscription.combineIdentifier)")
+            }, receiveOutput: { intValue in
+                print("in output handler, received \(intValue)")
+            }, receiveCompletion: { _ in
+                print("in completion handler")
+            }, receiveCancel: {
+                print("received cancel")
+            }, receiveRequest: { (demand) in
+                print("received demand: \(demand.description)")
+            })
+            .sink { _ in }
+            .store(in: &cancellables)
+
+        /*
+         Prints:
+
+         Subscription received: 0x6000004c3b80
+         received demand: unlimited
+         in output handler, received 1
+         in output handler, received 2
+         in output handler, received 3
+         in completion handler
+         */
+    }
+}

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/126, https://github.com/crazymanish/what-matters-most/pull/127, https://github.com/crazymanish/what-matters-most/pull/128, https://github.com/crazymanish/what-matters-most/pull/129
 - [ ] Debugging
     - [x] Printing events https://github.com/crazymanish/what-matters-most/pull/130
-    - [ ] Acting on events
+    - [x] Acting on events https://github.com/crazymanish/what-matters-most/pull/131
     - [ ] Using debugger
     - [ ] Practices
 - [ ] Error Handling


### PR DESCRIPTION
### Context
- Close ticket: #40 

### Acting events
- Besides printing out information, it is often useful to perform actions upon specific events.
- We call this performing side effects, as actions you take “on the side” don’t directly impact further publishers down the stream, but can have an effect like modifying an external variable.
- `handleEvents(receiveSubscription:receiveOutput:receiveCompletion:receiveCancel:receiveRequest:)` Performs the specified closures when publisher events occur.
  - `receiveSubscription:` An optional closure that executes when the publisher receives the subscription from the upstream publisher. This value defaults to nil.
  - `receiveOutput:` An optional closure that executes when the publisher receives a value from the upstream publisher. This value defaults to nil.
  - `receiveCompletion:` An optional closure that executes when the upstream publisher finishes normally or terminates with an error. This value defaults to nil.
  - `receiveCancel:` An optional closure that executes when the downstream receiver cancels publishing. This value defaults to nil.
  - `receiveRequest:` An optional closure that executes when the publisher receives a request for more elements. This value defaults to nil.
- https://developer.apple.com/documentation/combine/publisher/handleevents(receivesubscription:receiveoutput:receivecompletion:receivecancel:receiverequest:)

### In this PR
- Handling events using different callbacks