### PR TITLE
OR-5278 Debugging:: Using Breakpoint debugger

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9609A73A2A87F6DC00383991 /* NetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A7392A87F6DC00383991 /* NetworkingTests.swift */; };
 		9609A73D2A891B1700383991 /* PrintingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A73C2A891B1700383991 /* PrintingEventsTests.swift */; };
 		9609A73F2A8923E800383991 /* HandlingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A73E2A8923E800383991 /* HandlingEventsTests.swift */; };
+		9609A7412A8927F600383991 /* DebuggerBreakpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609A7402A8927F600383991 /* DebuggerBreakpointTests.swift */; };
 		9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */; };
 		9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */; };
 		9612D6B22A5AD0F9007CBD1A /* ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */; };
@@ -90,6 +91,7 @@
 		9609A7392A87F6DC00383991 /* NetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingTests.swift; sourceTree = "<group>"; };
 		9609A73C2A891B1700383991 /* PrintingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingEventsTests.swift; sourceTree = "<group>"; };
 		9609A73E2A8923E800383991 /* HandlingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlingEventsTests.swift; sourceTree = "<group>"; };
+		9609A7402A8927F600383991 /* DebuggerBreakpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggerBreakpointTests.swift; sourceTree = "<group>"; };
 		9609DCF32A5AB7E500A3B065 /* TryMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryMapTests.swift; sourceTree = "<group>"; };
 		9612D6AF2A5ACE06007CBD1A /* ReplaceEmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceEmptyTests.swift; sourceTree = "<group>"; };
 		9612D6B12A5AD0F9007CBD1A /* ScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTests.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 			children = (
 				9609A73C2A891B1700383991 /* PrintingEventsTests.swift */,
 				9609A73E2A8923E800383991 /* HandlingEventsTests.swift */,
+				9609A7402A8927F600383991 /* DebuggerBreakpointTests.swift */,
 			);
 			path = Debugging;
 			sourceTree = "<group>";
@@ -566,6 +569,7 @@
 				96321F072A5AACA400C60D8A /* MapTests.swift in Sources */,
 				9642B7A529D365D100CB89C8 /* EmptyTests.swift in Sources */,
 				9631D2C229DD156A00A9D790 /* JSONDecodingTests.swift in Sources */,
+				9609A7412A8927F600383991 /* DebuggerBreakpointTests.swift in Sources */,
 				9631D29529D7036200A9D790 /* DefaultValueTests.swift in Sources */,
 				967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */,
 				9642B76329D2130600CB89C8 /* CombineDemoTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Debugging/DebuggerBreakpointTests.swift
+++ b/CombineDemo/CombineDemoTests/Debugging/DebuggerBreakpointTests.swift
@@ -1,0 +1,90 @@
+//
+//  DebuggerBreakpointTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 13/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+- in some situations, we really need to introspect things at certain times in the debugger to figure out what’s wrong.
+- There are two debugger operators:
+
+ - `breakpointOnError()` Raises a debugger signal upon receiving a failure.
+ - https://developer.apple.com/documentation/combine/publisher/breakpointonerror()
+ - When the upstream publisher fails with an error, this publisher raises the SIGTRAP signal, which stops the process in the debugger.
+ - Otherwise, this publisher passes through values and completions as-is.
+
+ - `breakpoint(receiveSubscription:receiveOutput:receiveCompletion:)` Raises a debugger signal when a provided closure needs to stop the process in the debugger.
+   - receiveSubscription: A closure that executes when the publisher receives a subscription. Return true from this closure to raise SIGTRAP, or false to continue.
+   - receiveOutput: A closure that executes when the publisher receives a value. Return true from this closure to raise SIGTRAP, or false to continue.
+   - receiveCompletion: A closure that executes when the publisher receives a completion. Return true from this closure to raise SIGTRAP, or false to continue.
+ - https://developer.apple.com/documentation/combine/publisher/breakpoint(receivesubscription:receiveoutput:receivecompletion:)
+ - Use breakpoint(receiveSubscription:receiveOutput:receiveCompletion:) to examine one or more stages of the subscribe/publish/completion process and stop in the debugger, based on conditions you specify.
+ - When any of the provided closures returns true, this operator raises the SIGTRAP signal to stop the process in the debugger.
+ - Otherwise, this publisher passes through values and completions as-is.
+ */
+final class DebuggerBreakpointTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+
+        super.tearDown()
+    }
+
+    func testBreakpointOnErrorOperator() {
+        let publisher = PassthroughSubject<String?, ApiError>()
+
+        publisher
+            .tryMap({ _ in
+                throw ApiError(code: .notFound)
+            })
+            .breakpointOnError() // The breakpointOnError() operator receives this completion and stops the app in the debugger.
+            .sink { completion in
+                print("Completion: \(String(describing: completion))")
+            } receiveValue: { stringValue in
+                print("Result: \(String(describing: stringValue))")
+            }
+            .store(in: &cancellables)
+
+        publisher.send("sending test value for break-point debugger")
+
+        /*
+         - it will throw "error: Execution was interrupted, reason: signal SIGTRAP."
+         - Also include stack trace information in Xcode's left-side debugger panel.
+         */
+    }
+
+    func testBreakpointOnReceivedValueOperator() {
+        let publisher = PassthroughSubject<String, ApiError>()
+
+        publisher
+            .breakpoint(receiveOutput: { stringValue in
+                return stringValue == "DEBUGGER" // When the breakpoint receives the string “DEBUGGER”, it returns true, which stops the app in the debugger.
+            })
+            .sink { completion in
+                print("Completion: \(String(describing: completion))")
+            } receiveValue: { stringValue in
+                print("Result: \(String(describing: stringValue))")
+            }
+            .store(in: &cancellables)
+
+        publisher.send("this will not hit Debugger breakpoint")
+        publisher.send("DEBUGGER") // This will stop the app in the debugger after hitting the breakpoint
+
+        /*
+         - it will throw "error: Execution was interrupted, reason: signal SIGTRAP."
+         - Also include stack trace information in Xcode's left-side debugger panel.
+         */
+    }
+}

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 - [ ] Debugging
     - [x] Printing events https://github.com/crazymanish/what-matters-most/pull/130
     - [x] Acting on events https://github.com/crazymanish/what-matters-most/pull/131
-    - [ ] Using debugger
+    - [x] Using Breakpoint debugger https://github.com/crazymanish/what-matters-most/pull/132
     - [ ] Practices
 - [ ] Error Handling
     - [ ] Never


### PR DESCRIPTION
### Context
- Close ticket: #41 

### Breakpoint debugger
- in some situations, we really need to introspect things at certain times in the debugger to figure out what’s wrong.
- There are two debugger operators:
  - `breakpointOnError()` Raises a debugger signal upon receiving a failure.
  - https://developer.apple.com/documentation/combine/publisher/breakpointonerror()
  - When the upstream publisher fails with an error, this publisher raises the SIGTRAP signal, which stops the process in the debugger.
  - Otherwise, this publisher passes through values and completions as-is.
  - ----------------
  - `breakpoint(receiveSubscription:receiveOutput:receiveCompletion:)` Raises a debugger signal when a provided closure needs to stop the process in the debugger.
     - `receiveSubscription:` A closure that executes when the publisher receives a subscription. Return true from this closure to raise SIGTRAP, or false to continue.
     - `receiveOutput:` A closure that executes when the publisher receives a value. Return true from this closure to raise SIGTRAP, or false to continue.
     - `receiveCompletion:` A closure that executes when the publisher receives a completion. Return true from this closure to raise SIGTRAP, or false to continue.
   - https://developer.apple.com/documentation/combine/publisher/breakpoint(receivesubscription:receiveoutput:receivecompletion:)
  - Use breakpoint(receiveSubscription:receiveOutput:receiveCompletion:) to examine one or more stages of the subscribe/publish/completion process and stop in the debugger, based on conditions you specify.
  - When any of the provided closures returns true, this operator raises the SIGTRAP signal to stop the process in the debugger.
  - Otherwise, this publisher passes through values and completions as-is.

### In this PR
- Halting app using the breakpoint debugger **with stack-trace**