### PR TITLE
OR-5280 Error handling :: Never

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7A629D369A600CB89C8 /* ApiError.swift */; };
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
 		96442C5C2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */; };
+		965D33CD2A8D454400554D1D /* NeverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965D33CC2A8D454400554D1D /* NeverTests.swift */; };
 		966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */; };
 		966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784782A5B057F00398D70 /* CompactMapTests.swift */; };
 		9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */; };
@@ -132,6 +133,7 @@
 		9642B7A629D369A600CB89C8 /* ApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiError.swift; sourceTree = "<group>"; };
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
 		96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceQueryingValuesTests.swift; sourceTree = "<group>"; };
+		965D33CC2A8D454400554D1D /* NeverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverTests.swift; sourceTree = "<group>"; };
 		966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDuplicateTests.swift; sourceTree = "<group>"; };
 		966784782A5B057F00398D70 /* CompactMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMapTests.swift; sourceTree = "<group>"; };
 		9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputTests.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 			isa = PBXGroup;
 			children = (
 				9642B76229D2130600CB89C8 /* CombineDemoTests.swift */,
+				965D33CB2A8D451C00554D1D /* ErrorHandling */,
 				9609A73B2A891AF500383991 /* Debugging */,
 				9609A7382A87F6A900383991 /* Networking */,
 				96321F022A5AA2E100C60D8A /* Operators */,
@@ -373,6 +376,14 @@
 				9631D2C329DD161500A9D790 /* URLSession+Decodable.swift */,
 			);
 			path = TestHelpers;
+			sourceTree = "<group>";
+		};
+		965D33CB2A8D451C00554D1D /* ErrorHandling */ = {
+			isa = PBXGroup;
+			children = (
+				965D33CC2A8D454400554D1D /* NeverTests.swift */,
+			);
+			path = ErrorHandling;
 			sourceTree = "<group>";
 		};
 		967AF3A72A485BF700AB60CA /* Subject */ = {
@@ -604,6 +615,7 @@
 				9612D6B02A5ACE06007CBD1A /* ReplaceEmptyTests.swift in Sources */,
 				9609A73F2A8923E800383991 /* HandlingEventsTests.swift in Sources */,
 				96DACA652A640249004404AE /* ThrottleTests.swift in Sources */,
+				965D33CD2A8D454400554D1D /* NeverTests.swift in Sources */,
 				9642B7A729D369A600CB89C8 /* ApiError.swift in Sources */,
 				96DACA5F2A630C5E004404AE /* ShiftingTimeTests.swift in Sources */,
 				96442C5C2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/ErrorHandling/NeverTests.swift
+++ b/CombineDemo/CombineDemoTests/ErrorHandling/NeverTests.swift
@@ -1,0 +1,97 @@
+//
+//  NeverTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+@testable import CombineDemo
+
+/// - A publisher whose Failure is of type Never indicates that the publisher can never fail.
+/// - A publisher with Never failure type lets you focus on consuming the publisher's values, while being absolutely sure the publisher will never fail. It can only complete successfully once it's done.
+final class NeverTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValue: String?
+    var receivedError: ApiError?
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValue = nil
+        receivedError = nil
+
+        super.tearDown()
+    }
+
+    func testNeverErrorPublisher() {
+        let publisher = Just("Never going to fail") // Just is always Never failure type
+
+        publisher.sink { [weak self] completion in
+            switch completion { // No need to implement failure switch
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, "Never going to fail")
+        XCTAssertNil(receivedError)
+    }
+
+    func testNeverErrorWithFailureTypePublisher() {
+        let publisher = Just("Never going to fail") // Just is always Never failure type
+
+        publisher
+            .setFailureType(to: ApiError.self) // This will change the above Never publisher, can return ApiError
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):           // Failure switch is required because of setFailureType
+                self?.receivedError = error
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, "Never going to fail")
+        XCTAssertNil(receivedError)
+    }
+
+    func testNeverErrorWithFailureTypeAndLaterMakeNeverAgainPublisher() {
+        let publisher = Just("Never going to fail") // Just is always Never failure type
+
+        publisher
+            .setFailureType(to: ApiError.self) // This will change the above Never publisher, can return ApiError
+            .assertNoFailure() // This will change it back to Never publisher, and will never return Error (it will crash if error received from Top stream)
+            .sink { [weak self] completion in
+            switch completion { // No need to implement failure switch
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { [weak self] value in
+            self?.receivedValue = value
+        }
+        .store(in: &cancellables)
+
+        XCTAssertTrue(isFinishedCalled)
+        XCTAssertEqual(receivedValue, "Never going to fail")
+        XCTAssertNil(receivedError)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
     - [x] Using Breakpoint debugger https://github.com/crazymanish/what-matters-most/pull/132
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/130, https://github.com/crazymanish/what-matters-most/pull/131, https://github.com/crazymanish/what-matters-most/pull/132, https://github.com/crazymanish/what-matters-most/pull/133
 - [ ] Error Handling
-    - [ ] Never
+    - [x] Never https://github.com/crazymanish/what-matters-most/pull/134
     - [ ] Dealing with failure
     - [ ] Practices
 - [ ] Schedulers


### PR DESCRIPTION
### Context
- Close ticket: #43 

### Error handling :: Never
- A publisher whose Failure is of type `Neve`r **indicates that** the publisher can `never fail.`
- A publisher with Never failure type lets you focus on consuming the publisher's values, while being absolutely sure the publisher will never fail. It can only complete successfully once it's done.

### In this PR
- Never error-type
- Make Never publisher to Error-Type
- Make Error-Type to Never publisher