### PR TITLE
OR-5281 Error handling :: Dealing with failure

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		9642B7F729D4C54600CB89C8 /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9642B7F629D4C54600CB89C8 /* FailTests.swift */; };
 		96442C5C2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */; };
 		965D33CD2A8D454400554D1D /* NeverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965D33CC2A8D454400554D1D /* NeverTests.swift */; };
+		965D33CF2A8D4F6000554D1D /* DealingWithFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 965D33CE2A8D4F6000554D1D /* DealingWithFailureTests.swift */; };
 		966784772A5B00AD00398D70 /* RemoveDuplicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */; };
 		966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966784782A5B057F00398D70 /* CompactMapTests.swift */; };
 		9667847B2A5B09DC00398D70 /* IgnoreOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */; };
@@ -134,6 +135,7 @@
 		9642B7F629D4C54600CB89C8 /* FailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
 		96442C5B2A800CE000C13BA8 /* SequenceQueryingValuesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceQueryingValuesTests.swift; sourceTree = "<group>"; };
 		965D33CC2A8D454400554D1D /* NeverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverTests.swift; sourceTree = "<group>"; };
+		965D33CE2A8D4F6000554D1D /* DealingWithFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealingWithFailureTests.swift; sourceTree = "<group>"; };
 		966784762A5B00AD00398D70 /* RemoveDuplicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveDuplicateTests.swift; sourceTree = "<group>"; };
 		966784782A5B057F00398D70 /* CompactMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMapTests.swift; sourceTree = "<group>"; };
 		9667847A2A5B09DC00398D70 /* IgnoreOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreOutputTests.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 			isa = PBXGroup;
 			children = (
 				965D33CC2A8D454400554D1D /* NeverTests.swift */,
+				965D33CE2A8D4F6000554D1D /* DealingWithFailureTests.swift */,
 			);
 			path = ErrorHandling;
 			sourceTree = "<group>";
@@ -603,6 +606,7 @@
 				96321F092A5AB41200C60D8A /* MapKeypathTests.swift in Sources */,
 				9642B78329D28DEA00CB89C8 /* DispatchQueueType.swift in Sources */,
 				9631D29E29DB503900A9D790 /* URLSessionTests.swift in Sources */,
+				965D33CF2A8D4F6000554D1D /* DealingWithFailureTests.swift in Sources */,
 				9642B77E29D2149A00CB89C8 /* JustTests.swift in Sources */,
 				9631D2A029DBC51600A9D790 /* UserDefaultTests.swift in Sources */,
 				96DACA692A64190F004404AE /* MeasureTimeTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/ErrorHandling/DealingWithFailureTests.swift
+++ b/CombineDemo/CombineDemoTests/ErrorHandling/DealingWithFailureTests.swift
@@ -1,0 +1,137 @@
+//
+//  DealingWithFailureTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 16/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+@testable import CombineDemo
+
+/// - All try* operators
+/// - The try-prefixed operators let you throw errors from within them, while non-try operators do not.
+/// - All try-prefixed operators in Combine behave the same way when it comes to errors.
+/// - Example: tryMap, tryFirst, tryLast etc
+///
+/// - `mapError(_:)` Converts any failure from the upstream publisher into a new error.
+/// - https://developer.apple.com/documentation/combine/fail/maperror(_:)/
+///
+/// - `replaceError(with:)` Replaces any errors in the stream with the provided element.
+/// - If the upstream publisher fails with an error, this publisher emits the provided element, then finishes normally.
+/// - This replaceError(with:) functionality is useful when you want to handle an error by sending a single replacement element and end the stream.
+/// - https://developer.apple.com/documentation/combine/deferred/replaceerror(with:)/
+final class DealingWithFailureTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValue: String?
+    var receivedError: ApiError?
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValue = nil
+        receivedError = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithTryMapOperator() {
+        // Given: Publisher
+        let publisher = [10, 20, 15, 25, 5].publisher
+        var receivedValues: [String] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .tryMap { try self.romanNumeral(from: $0) }
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                self?.receivedError = error as? ApiError
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, ["X", "XX", "XV", "XXV"])
+        XCTAssertEqual(receivedError?.code, .notFound) // Finished with correct error
+    }
+
+    private func romanNumeral(from: Int) throws -> String {
+        let romanNumeralDict = [10:"X", 20:"XX", 15:"XV", 25:"XXV"]
+
+        guard let numeral = romanNumeralDict[from] else {
+            throw ApiError(code: .notFound)
+        }
+
+        return numeral
+    }
+
+    func testMapErrorOperator() {
+        // Given: Publisher
+        let publisher = [10, 20, 15, 25, 5].publisher
+        var receivedValues: [String] = []
+        var receivedGenericError: GenericError?
+
+        // When: Sink(Subscription)
+        publisher
+            .tryMap { try self.romanNumeral(from: $0) } // This is returning ApiError
+            .mapError { GenericError(wrappedError: $0) } // This will change ApiError to GenericError
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            case .failure(let error):
+                receivedGenericError = error
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertFalse(isFinishedCalled) // Successful finished is not called because Upstream got an error
+        XCTAssertEqual(receivedValues, ["X", "XX", "XV", "XXV"])
+        XCTAssertNotNil(receivedGenericError) // Finished with correct error
+    }
+
+    func testPublisherWithReplaceErrorOperator() {
+        // Given: Publisher
+        let publisher = [10, 20, 15, 25, 5].publisher
+        var receivedValues: [String] = []
+
+        // When: Sink(Subscription)
+        publisher
+            .tryMap { try self.romanNumeral(from: $0) }
+            .replaceError(with: "ReplacedError") // This will make it NEVER fail type
+            .sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                self?.isFinishedCalled = true
+            }
+        } receiveValue: { value in
+            receivedValues.append(value)
+        }
+        .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled) // Successful finished is called because Upstream error is replaced by a valid string value
+        XCTAssertEqual(receivedValues, ["X", "XX", "XV", "XXV", "ReplacedError"])
+        XCTAssertNil(receivedError) // Finished with no error
+    }
+}
+
+struct GenericError: Error { var wrappedError: Error }

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/130, https://github.com/crazymanish/what-matters-most/pull/131, https://github.com/crazymanish/what-matters-most/pull/132, https://github.com/crazymanish/what-matters-most/pull/133
 - [ ] Error Handling
     - [x] Never https://github.com/crazymanish/what-matters-most/pull/134
-    - [ ] Dealing with failure
+    - [x] Dealing with failure https://github.com/crazymanish/what-matters-most/pull/135
+      - `try-prefixed operators i.e tryMap`
+      - `mapError(_:)`
+      - `replaceError(with:)`
     - [ ] Practices
 - [ ] Schedulers
     - [ ] Operators for scheduling


### PR DESCRIPTION
### Context
- Close ticket: #44 

### In this PR
- All try* operators
- The try-prefixed operators let you throw errors from within them, while non-try operators do not.
- All try-prefixed operators in Combine behave the same way when it comes to errors.
- Example: tryMap, tryFirst, tryLast etc
--------------
- `mapError(_:)` Converts any failure from the upstream publisher into a new error.
- https://developer.apple.com/documentation/combine/fail/maperror(_:)/
---------------
- `replaceError(with:)` Replaces any errors in the stream with the provided element.
- If the upstream publisher fails with an error, this publisher emits the provided element, then finishes normally.
- This replaceError(with:) functionality is useful when you want to handle an error by sending a single replacement element and end the stream.
- https://developer.apple.com/documentation/combine/deferred/replaceerror(with:)/