### PR TITLE
OR-5282 Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@
     - [x] Acting on events https://github.com/crazymanish/what-matters-most/pull/131
     - [x] Using Breakpoint debugger https://github.com/crazymanish/what-matters-most/pull/132
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/130, https://github.com/crazymanish/what-matters-most/pull/131, https://github.com/crazymanish/what-matters-most/pull/132, https://github.com/crazymanish/what-matters-most/pull/133
-- [ ] Error Handling
+- [x] Error Handling
     - [x] Never https://github.com/crazymanish/what-matters-most/pull/134
     - [x] Dealing with failure https://github.com/crazymanish/what-matters-most/pull/135
       - `try-prefixed operators i.e tryMap`
       - `mapError(_:)`
       - `replaceError(with:)`
-    - [ ] Practices
+    - [x] Practices https://github.com/crazymanish/what-matters-most/pull/134, https://github.com/crazymanish/what-matters-most/pull/135, https://github.com/crazymanish/what-matters-most/pull/136
 - [ ] Schedulers
     - [ ] Operators for scheduling
     - [ ] Practices


### PR DESCRIPTION
### Context
- Close ticket: #45 

### In this PR
- Base branch of below PRs:
- https://github.com/crazymanish/what-matters-most/pull/134
- https://github.com/crazymanish/what-matters-most/pull/135

### Highlights
- Publishers with a Failure type of **Never are guaranteed** to not emit a failure completion event.
- The `try-prefixed` operators let you throw errors from within them, while **non-try operators do not.**
- Since Swift doesn't support typed throws, calling `try-prefixed operators` erases the publisher's Failure to a plain Swift Error.
- `Use mapError` to map a publisher's Failure type, and unify all failure types in your publisher to a single type.
  - When creating your own API based on other publishers with their own Failure types, `wrap all possible errors into your own Error type` to unify them and hide your API's implementation details.
- You can use the retry operator to resubscribe to a failed publisher for an additional number of times.
`replaceError(with:)` is useful when you want to provide a default fallback value for your publisher, in case of failure.
- Finally, you may use `catch` to replace a failed publisher with a different fallback publisher.