### PR TITLE
OR-5283 Schedulers:: Scheduler implementations:: ImmediateScheduler

### DIFF
--- a/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
+++ b/CombineDemo/CombineDemo.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		967AF3A92A485C3100AB60CA /* PassthroughSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */; };
 		967AF4B92A526E0600AB60CA /* CurrentValueSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */; };
 		967C6CB62A5AC96300461FF3 /* ReplaceNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */; };
+		96A3B1562A8E7BCC00CDD372 /* SchedulerImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A3B1552A8E7BCC00CDD372 /* SchedulerImplementationTests.swift */; };
 		96AC4A2E2A5FB47E00B2042E /* PrependingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */; };
 		96AC4A302A5FC02600B2042E /* AppendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */; };
 		96AC4A322A5FC44000B2042E /* SwitchToLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */; };
@@ -146,6 +147,7 @@
 		967AF3A82A485C3100AB60CA /* PassthroughSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughSubjectTests.swift; sourceTree = "<group>"; };
 		967AF4B82A526E0600AB60CA /* CurrentValueSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueSubjectTests.swift; sourceTree = "<group>"; };
 		967C6CB52A5AC96300461FF3 /* ReplaceNilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceNilTests.swift; sourceTree = "<group>"; };
+		96A3B1552A8E7BCC00CDD372 /* SchedulerImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerImplementationTests.swift; sourceTree = "<group>"; };
 		96AC4A2D2A5FB47E00B2042E /* PrependingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrependingTests.swift; sourceTree = "<group>"; };
 		96AC4A2F2A5FC02600B2042E /* AppendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendingTests.swift; sourceTree = "<group>"; };
 		96AC4A312A5FC44000B2042E /* SwitchToLatestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatestTests.swift; sourceTree = "<group>"; };
@@ -396,6 +398,7 @@
 			isa = PBXGroup;
 			children = (
 				965D33E22A8E36C700554D1D /* SchedulerTests.swift */,
+				96A3B1552A8E7BCC00CDD372 /* SchedulerImplementationTests.swift */,
 			);
 			path = Scheduler;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				9631D29C29DA736200A9D790 /* NotificationTests.swift in Sources */,
 				96AC4A462A60081500B2042E /* CombineLatestTests.swift in Sources */,
 				9631D2EA29E657D500A9D790 /* IntSubscriberTests.swift in Sources */,
+				96A3B1562A8E7BCC00CDD372 /* SchedulerImplementationTests.swift in Sources */,
 				966784792A5B057F00398D70 /* CompactMapTests.swift in Sources */,
 				9609DCF42A5AB7E500A3B065 /* TryMapTests.swift in Sources */,
 				96B40BD02A7E653A001D06AF /* SequenceFindingValuesTests.swift in Sources */,

--- a/CombineDemo/CombineDemoTests/Scheduler/SchedulerImplementationTests.swift
+++ b/CombineDemo/CombineDemoTests/Scheduler/SchedulerImplementationTests.swift
@@ -1,0 +1,87 @@
+//
+//  SchedulerImplementationTests.swift
+//  CombineDemoTests
+//
+//  Created by Manish Rathi on 17/08/2023.
+//
+
+import Foundation
+import Combine
+import XCTest
+
+/*
+- Scheduler implementations
+- Apple provides several concrete implementations of the Scheduler protocol:
+-----------
+- `ImmediateScheduler:` A simple scheduler that executes code immediately on the current thread, which is the default execution context unless modified using subscribe(on:), receive(on:) or any of the other operators which take a scheduler as parameter.
+- You can only use this scheduler for immediate actions. If you attempt to schedule actions after a specific date, this scheduler ignores the date and performs them immediately.
+- https://developer.apple.com/documentation/combine/immediatescheduler
+-----------
+- `RunLoop:` Tied to Foundation’s Thread object.
+- `DispatchQueue:` Can either be serial or concurrent.
+- `OperationQueue:` A queue that regulates the execution of work items.
+ */
+final class SchedulerImplementationTests: XCTestCase {
+    var cancellables: Set<AnyCancellable>!
+    var isFinishedCalled: Bool!
+    var receivedValues: [String]?
+    var receivedError: ApiError?
+
+    override func setUp() {
+        super.setUp()
+
+        cancellables = []
+        receivedValues = []
+        isFinishedCalled =  false
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        isFinishedCalled = nil
+        receivedValues = nil
+        receivedError = nil
+
+        super.tearDown()
+    }
+
+    func testPublisherWithImmediateScheduler() {
+        let expectation = XCTestExpectation(description: "Performing expensive computation in main thread with immediateScheduler")
+
+        // Given: Publisher
+        // ExpensiveComputation: which simulates a long-running computation that emits a string after the specified duration.
+        let publisher = Publishers.ExpensiveComputation(duration: 3)
+
+        // You obtain the current execution thread number. The main thread (thread number 1) is the default thread your code runs in.
+        let currentThread = Thread.current.number
+        print("Start computation publisher on thread \(currentThread)")
+        XCTAssertEqual(currentThread, 1)
+
+        let immediateScheduler = ImmediateScheduler.shared
+
+        // When: Sink(Subscription)
+        publisher
+            .receive(on: immediateScheduler) // immediateScheduler executes immediately on the current thread, and in this case that thread is the main thread.
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { [weak self] value in
+                let thread = Thread.current.number
+                print("Received computation result on thread \(thread): '\(value)'")
+                XCTAssertEqual(currentThread, 1)
+
+                self?.receivedValues?.append(value)
+            }
+            .store(in: &cancellables)
+
+        // Then: Receiving correct value
+        XCTAssertTrue(isFinishedCalled) // Successful finished
+        XCTAssertEqual(receivedValues, ["Computation complete"])
+        XCTAssertNil(receivedError) // No error
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@
     - [x] Operators for scheduling https://github.com/crazymanish/what-matters-most/pull/137
       - `subscribe(on:)` and `subscribe(on:options:)`
       - `receive(on:)` and `receive(on:options:)`
+    - [x] Scheduler implementations
+      - `ImmediateScheduler` https://github.com/crazymanish/what-matters-most/pull/138
     - [ ] Practices
 - [ ] Timers
     - [ ] Using RunLoop


### PR DESCRIPTION
### Context
- Close ticket: #47 

### Scheduler
- https://developer.apple.com/documentation/combine/scheduler/
- A scheduler is a protocol that defines when and how to execute a closure.
- You can use a scheduler to execute code as soon as possible, or after a future date.
- Schedulers can accept options to control how they execute the actions passed to them. These options may control factors like which threads or dispatch queues execute the actions.

### In this PR
- Schedulers:: Scheduler implementations:: ImmediateScheduler
- Apple provides several concrete implementations of the Scheduler protocol:
-----------
- `ImmediateScheduler:` A simple scheduler that executes code immediately on the current thread, which is the default execution context unless modified using subscribe(on:), receive(on:) or any of the other operators which take a scheduler as parameter.
- You can only use this scheduler for immediate actions. If you attempt to schedule actions after a specific date, this scheduler ignores the date and performs them immediately.
- https://developer.apple.com/documentation/combine/immediatescheduler
-----------
- `RunLoop:` Tied to Foundation’s Thread object.
- `DispatchQueue:` Can either be serial or concurrent.
- `OperationQueue:` A queue that regulates the execution of work items.