### PR TITLE
OR-5284 Schedulers:: Scheduler implementations:: `RunLoop` `DispatchQueue` `OperationQueue`

### DIFF
--- a/CombineDemo/CombineDemoTests/Scheduler/SchedulerImplementationTests.swift
+++ b/CombineDemo/CombineDemoTests/Scheduler/SchedulerImplementationTests.swift
@@ -18,8 +18,18 @@ import XCTest
 - https://developer.apple.com/documentation/combine/immediatescheduler
 -----------
 - `RunLoop:` Tied to Foundation’s Thread object.
+- The RunLoop scheduler is used to execute tasks on a particular run loop.
+- Actions on a run loop can be unsafe because RunLoops are not thread-safe. Therefore, using a DispatchQueue is a better option.
+-----------
 - `DispatchQueue:` Can either be serial or concurrent.
-- `OperationQueue:` A queue that regulates the execution of work items.
+- Dispatch queues are FIFO queues. Dispatch queues execute tasks either serially or concurrently.
+- Work submitted to dispatch queues executes on a pool of threads managed by the system. Except for the dispatch queue representing your app’s main thread, the system makes no guarantees about which thread it uses to execute a task.
+- A DispatchQueue can be either serial (the default) or concurrent.
+-----------
+- `OperationQueue:` A queue that regulates the execution of operations.
+- It is a rich regulation mechanism that lets you create advanced operations with dependencies.
+- OperationQueue uses DispatchQueue under the hood. Moreover, there is one parameter in each OperationQueue that explains everything: It’s `maxConcurrentOperationCount`. It defaults to a system-defined number that allows an operation queue to execute a large number of operations concurrently.
+- By default, an OperationQueue behaves like a concurrent DispatchQueue. Setting maxConcurrentOperationCount to 1 is equivalent to using a serial queue
  */
 final class SchedulerImplementationTests: XCTestCase {
     var cancellables: Set<AnyCancellable>!
@@ -71,7 +81,7 @@ final class SchedulerImplementationTests: XCTestCase {
             } receiveValue: { [weak self] value in
                 let thread = Thread.current.number
                 print("Received computation result on thread \(thread): '\(value)'")
-                XCTAssertEqual(currentThread, 1)
+                XCTAssertEqual(thread, 1)
 
                 self?.receivedValues?.append(value)
             }
@@ -81,6 +91,181 @@ final class SchedulerImplementationTests: XCTestCase {
         XCTAssertTrue(isFinishedCalled) // Successful finished
         XCTAssertEqual(receivedValues, ["Computation complete"])
         XCTAssertNil(receivedError) // No error
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testPublisherWithExpensiveComputationInMainQueue() {
+        let expectation = XCTestExpectation(description: "Performing expensive computation in main queue")
+
+        // Given: Publisher
+        // ExpensiveComputation: which simulates a long-running computation that emits a string after the specified duration.
+        let publisher = Publishers.ExpensiveComputation(duration: 3)
+
+        // Main Queue
+        let queue = DispatchQueue.main
+
+        // You obtain the current execution thread number. The main thread (thread number 1) is the default thread your code runs in.
+        let currentThread = Thread.current.number
+        print("Start computation publisher on thread \(currentThread)")
+        XCTAssertEqual(currentThread, 1)
+
+        // When: Sink(Subscription)
+        publisher
+            .subscribe(on: queue) // `subscribe(on:)`: `create` the subscription (start the work) on the specified scheduler i.e background queue.
+            .receive(on: queue)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { [weak self] value in
+                let thread = Thread.current.number
+                print("Received computation result on thread \(thread): '\(value)'")
+                XCTAssertEqual(thread, 1)
+
+                DispatchQueue.main.async { // We need to update UI, because code were switched to background thread using in `subscribe(on: queue)` step (see below for better alternative)
+                    self?.receivedValues?.append(value)
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testPublisherWithExpensiveComputationInSerialQueue() {
+        let expectation = XCTestExpectation(description: "Performing expensive computation in serial queue")
+
+        // Given: Publisher
+        // ExpensiveComputation: which simulates a long-running computation that emits a string after the specified duration.
+        let publisher = Publishers.ExpensiveComputation(duration: 3)
+
+        // A serial queue
+        let queue = DispatchQueue(label: "serial queue")
+
+        // You obtain the current execution thread number. The main thread (thread number 1) is the default thread your code runs in.
+        let currentThread = Thread.current.number
+        print("Start computation publisher on thread \(currentThread)")
+        XCTAssertEqual(currentThread, 1)
+
+        // When: Sink(Subscription)
+        publisher
+            .subscribe(on: queue) // `subscribe(on:)`: `create` the subscription (start the work) on the specified scheduler i.e background queue.
+            .receive(on: queue) // We will receive result in non-main thread, because using serial queue
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { [weak self] value in
+                let thread = Thread.current.number
+                print("Received computation result on thread \(thread): '\(value)'")
+                XCTAssertNotEqual(thread, 1) // 1 mean Main-Thread, it should not be 1
+
+                DispatchQueue.main.async { // We need to update UI, because code were switched to background thread using in `subscribe(on: queue)` step (see below for better alternative)
+                    self?.receivedValues?.append(value)
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testPublisherWithExpensiveComputationInParallelQueue() {
+        let expectation = XCTestExpectation(description: "Performing expensive computation in parallel queue")
+
+        // Given: Publisher
+        // ExpensiveComputation: which simulates a long-running computation that emits a string after the specified duration.
+        let publisher = Publishers.ExpensiveComputation(duration: 3)
+
+        // A parallel queue
+        let queue = DispatchQueue(label: "parallel queue", attributes: .concurrent)
+
+        // You obtain the current execution thread number. The main thread (thread number 1) is the default thread your code runs in.
+        let currentThread = Thread.current.number
+        print("Start computation publisher on thread \(currentThread)")
+        XCTAssertEqual(currentThread, 1)
+
+        // When: Sink(Subscription)
+        publisher
+            .subscribe(on: queue) // `subscribe(on:)`: `create` the subscription (start the work) on the specified scheduler i.e background queue.
+            .receive(on: queue) // We will receive result in non-main thread, because using serial queue
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { [weak self] value in
+                let thread = Thread.current.number
+                print("Received computation result on thread \(thread): '\(value)'")
+                XCTAssertNotEqual(thread, 1) // 1 mean Main-Thread, it should not be 1
+
+                DispatchQueue.main.async { // We need to update UI, because code were switched to background thread using in `subscribe(on: queue)` step (see below for better alternative)
+                    self?.receivedValues?.append(value)
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testPublisherWitOperationQueue() {
+        let expectation = XCTestExpectation(description: "using OperationQueue (concurrent DispatchQueue)")
+
+        // Given: Publisher
+        let publisher = (1...10).publisher
+        let queue = OperationQueue()
+
+        // When: Sink(Subscription)
+        publisher
+            .receive(on: queue) // We will receive result in non-main thread, because using OperationQueue (concurrent DispatchQueue)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { value in
+                let thread = Thread.current.number
+                print("Received result on thread \(thread): '\(value)'")
+                XCTAssertNotEqual(thread, 1) // 1 mean Main-Thread, it should not be 1
+            }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testPublisherWitOperationQueueWithMaxConcurrentOperationCount() {
+        let expectation = XCTestExpectation(description: "using OperationQueue with 1 maxConcurrentOperationCount (serial DispatchQueue)")
+
+        // Given: Publisher
+        let publisher = (1...10).publisher
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+
+        // When: Sink(Subscription)
+        publisher
+            .receive(on: queue) // We will receive result in non-main thread, because using OperationQueue (concurrent DispatchQueue)
+            .sink { [weak self] completion in
+                switch completion {
+                case .finished:
+                    self?.isFinishedCalled = true
+
+                    expectation.fulfill()
+                }
+            } receiveValue: { value in
+                let thread = Thread.current.number
+                print("Received result on thread \(thread): '\(value)'")
+                XCTAssertNotEqual(thread, 1) // 1 mean Main-Thread, it should not be 1
+            }
+            .store(in: &cancellables)
 
         wait(for: [expectation], timeout: 5.0)
     }

--- a/CombineDemo/CombineDemoTests/Scheduler/SchedulerTests.swift
+++ b/CombineDemo/CombineDemoTests/Scheduler/SchedulerTests.swift
@@ -121,9 +121,9 @@ final class SchedulerTests: XCTestCase {
             } receiveValue: { [weak self] value in
                 let thread = Thread.current.number
                 print("Received computation result on thread \(thread): '\(value)'")
-                XCTAssertEqual(currentThread, 1)
+                XCTAssertNotEqual(thread, 1) // 1 mean Main-Thread, it should not be 1 because we are using background queue
 
-                DispatchQueue.main.async { // We need to update UI, because code were switched to background thread using in `subscribe(on: queue)` step (see below for better alternative)
+                DispatchQueue.main.async { // We need this switch to update UI, because code were switched to background thread using in `subscribe(on: queue)` step (see below for better alternative)
                     self?.receivedValues?.append(value)
                 }
             }
@@ -162,7 +162,7 @@ final class SchedulerTests: XCTestCase {
             } receiveValue: { [weak self] value in
                 let thread = Thread.current.number
                 print("Received computation result on thread \(thread): '\(value)'")
-                XCTAssertEqual(currentThread, 1)
+                XCTAssertEqual(thread, 1) // 1 mean Main-Thread
 
                 self?.receivedValues?.append(value) // No need `DispatchQueue.main.async` thanks to `.receive(on: DispatchQueue.main)` step
             }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
       - `receive(on:)` and `receive(on:options:)`
     - [x] Scheduler implementations
       - `ImmediateScheduler` https://github.com/crazymanish/what-matters-most/pull/138
+      - `RunLoop` `DispatchQueue` `OperationQueue` https://github.com/crazymanish/what-matters-most/pull/139
     - [ ] Practices
 - [ ] Timers
     - [ ] Using RunLoop


### PR DESCRIPTION
### Context
- Close ticket: #47 

### Scheduler
- https://developer.apple.com/documentation/combine/scheduler/
- A scheduler is a protocol that defines when and how to execute a closure.
- You can use a scheduler to execute code as soon as possible, or after a future date.
- Schedulers can accept options to control how they execute the actions passed to them. These options may control factors like which threads or dispatch queues execute the actions.

### In this PR
- Schedulers:: Scheduler implementations:: ImmediateScheduler
- Apple provides several concrete implementations of the Scheduler protocol:
-----------
- `ImmediateScheduler:` A simple scheduler that executes code immediately on the current thread, which is the default execution context unless modified using subscribe(on:), receive(on:) or any of the other operators which take a scheduler as parameter.
- You can only use this scheduler for immediate actions. If you attempt to schedule actions after a specific date, this scheduler ignores the date and performs them immediately.
- https://developer.apple.com/documentation/combine/immediatescheduler
-----------
-----------
- `RunLoop:` Tied to Foundation’s Thread object.
- The RunLoop scheduler is used to execute tasks on a particular run loop.
- Actions on a run loop can be unsafe because **RunLoops are not thread-safe.** Therefore, using a DispatchQueue is a better option.
-----------
- `DispatchQueue:` Can either be serial or concurrent. `most versatile and useful scheduler` 🏆🥇
- Dispatch queues are FIFO queues. Dispatch queues execute tasks either serially or concurrently.
- Work submitted to dispatch queues executes on a pool of threads managed by the system. Except for the dispatch queue representing your app’s main thread, the system makes no guarantees about which thread it uses to execute a task.
- A DispatchQueue can be **either serial (the default) or concurrent.**
-----------
- `OperationQueue:` A queue that regulates the execution of operations.
- It is a rich regulation mechanism that lets you create advanced operations with dependencies.
- OperationQueue uses DispatchQueue under the hood. Moreover, there is one parameter in each OperationQueue that explains everything: It’s `maxConcurrentOperationCount`. It defaults to a system-defined number that allows an operation queue to execute a large number of operations concurrently.
- `By default`, an OperationQueue behaves like a **concurrent DispatchQueue.** Setting `maxConcurrentOperationCount to 1` is equivalent to using a **serial queue**.