### PR TITLE
OR-5284 Schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@
       - `mapError(_:)`
       - `replaceError(with:)`
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/134, https://github.com/crazymanish/what-matters-most/pull/135, https://github.com/crazymanish/what-matters-most/pull/136
-- [ ] Schedulers
+- [x] Schedulers
     - [x] Operators for scheduling https://github.com/crazymanish/what-matters-most/pull/137
       - `subscribe(on:)` and `subscribe(on:options:)`
       - `receive(on:)` and `receive(on:options:)`
     - [x] Scheduler implementations
       - `ImmediateScheduler` https://github.com/crazymanish/what-matters-most/pull/138
       - `RunLoop` `DispatchQueue` `OperationQueue` https://github.com/crazymanish/what-matters-most/pull/139
-    - [ ] Practices
+    - [x] Practices https://github.com/crazymanish/what-matters-most/pull/137, https://github.com/crazymanish/what-matters-most/pull/138, https://github.com/crazymanish/what-matters-most/pull/139, https://github.com/crazymanish/what-matters-most/pull/140
 - [ ] Timers
     - [ ] Using RunLoop
     - [ ] Using Timer class


### PR DESCRIPTION
### Context
- Close ticket: #47 

### In this PR
- Base branch of below PRs:
- https://github.com/crazymanish/what-matters-most/pull/137
- https://github.com/crazymanish/what-matters-most/pull/138
- https://github.com/crazymanish/what-matters-most/pull/139

### Highlights
- A Scheduler defines the execution context for a piece of work.
- Apple‘s operating systems offer a rich variety of tools to help you schedule code execution.
- Combine tops these schedulers with the Scheduler protocol to help you pick the best one for the job in any given situation.
- Every time you use `receive(on:)`, further operators in your publisher execute on the specified scheduler. That is, unless they themselves take a Scheduler parameter!