### PR TITLE
OR-5286 Timers:: Timer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/137, https://github.com/crazymanish/what-matters-most/pull/138, https://github.com/crazymanish/what-matters-most/pull/139, https://github.com/crazymanish/what-matters-most/pull/140
 - [ ] Timers
     - [x] Using RunLoop https://github.com/crazymanish/what-matters-most/pull/141
-    - [ ] Using Timer class
+    - [x] Using Timer class https://github.com/crazymanish/what-matters-most/pull/142
     - [ ] Using DispatchQueue
     - [ ] Practices
 - [ ] Key-value Observing


### PR DESCRIPTION
### Context
- Close ticket: #49 

### In this PR
- Before the Dispatch framework was available, developers relied on RunLoop to asynchronously perform tasks and implement concurrency.
- Timer (NSTimer in Objective-C) could be used to create repeating and non-repeating timers.
- Then Dispatch arrived and with it, DispatchSourceTimer.
----------
- Using RunLoop
- The main thread and any thread you create, preferably using the Thread class, can have its own RunLoop.
- It is always better, to use the main RunLoop that runs the main thread of your application. `RunLoop.main`
- **RunLoop class is not thread-safe.** means You should only call RunLoop methods for the run loop of the current thread.
- RunLoop defines several methods which are relatively low-level, and the **only one benefit that** lets you create `cancellable timers`
----------
- Using the **Timer class**
- Timer is the oldest timer that was available on the original Mac OS X, long before it was renamed “macOS.”
- It has always been tricky to use because of its delegation pattern and **tight relationship with RunLoop**.
- Combine brings a modern variant you can directly use as a publisher without all the setup boilerplate.