### PR TITLE
OR-5286 Timers:: Using DispatchQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@
 - [ ] Timers
     - [x] Using RunLoop https://github.com/crazymanish/what-matters-most/pull/141
     - [x] Using Timer class https://github.com/crazymanish/what-matters-most/pull/142
-    - [ ] Using DispatchQueue
+    - [x] Using DispatchQueue https://github.com/crazymanish/what-matters-most/pull/143
     - [ ] Practices
 - [ ] Key-value Observing
     - [ ] KVO introduction


### PR DESCRIPTION
### Context
- Close ticket: #50 

### In this PR
- Before the Dispatch framework was available, developers relied on RunLoop to asynchronously perform tasks and implement concurrency.
- Timer (NSTimer in Objective-C) could be used to create repeating and non-repeating timers.
- Then Dispatch arrived and with it, DispatchSourceTimer.
----------
- Using RunLoop
- The main thread and any thread you create, preferably using the Thread class, can have its own RunLoop.
- It is always better, to use the main RunLoop that runs the main thread of your application. `RunLoop.main`
- **RunLoop class is not thread-safe.** means You should only call RunLoop methods for the run loop of the current thread.
- RunLoop defines several methods which are relatively low-level, and the **only one benefit that** lets you create `cancellable timers`
----------
- Using **DispatchQueue**
- You can use a dispatch queue to generate timer events.
- While the Dispatch framework has a DispatchTimerSource event source, **Combine surprisingly doesn’t provide a timer interface to it.** Instead, you’re going to use an alternative method to generate timer events in your queue.