### PR TITLE
OR-5290 KeyValueObserving:: Swift ObservableObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/141, https://github.com/crazymanish/what-matters-most/pull/142, https://github.com/crazymanish/what-matters-most/pull/143, https://github.com/crazymanish/what-matters-most/pull/144
 - [ ] Key-value Observing
     - [x] KVO introduction https://github.com/crazymanish/what-matters-most/pull/145
-    - [ ] ObservableObject
+    - [x] ObservableObject https://github.com/crazymanish/what-matters-most/pull/146
     - [ ] Practices
 
   ------------------------------------------


### PR DESCRIPTION
### Context
- Close ticket: #53 

### In this PR
- Combine provides a few options around KVO:
 - For **ObjectiveC's** NSObject: It `provides a publisher` for any property of an object that is `KVO (Key-Value Observing)`-compliant.
 - For **Swift's** KVO: The `ObservableObject protocol` handles cases where multiple variables could change.
----------
- `publisher(for:options:)` for key-value observing
- https://developer.apple.com/documentation/combine/performing-key-value-observing-with-combine
- This is mostly for ObjectiveC because Swift language doesn’t directly support KVO, marking your properties `@objc dynamic` forces the compiler to generate hidden methods that trigger the KVO machinery.
----------
- `ObservableObject` A type of object with **a publisher that emits before the object has changed.**
- https://developer.apple.com/documentation/combine/observableobject
- By default an ObservableObject synthesizes an objectWillChange publisher that emits the changed value before any of its @Published properties changes.