### PR TITLE
OR-5291 KeyValueObserving:: ObjecticeC KVO v/s Swift ObservableObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
 - [x] Key-value Observing
     - [x] KVO introduction https://github.com/crazymanish/what-matters-most/pull/145
     - [x] ObservableObject https://github.com/crazymanish/what-matters-most/pull/146
-    - [x] Practices https://github.com/crazymanish/what-matters-most/pull/147
+    - [x] Practices https://github.com/crazymanish/what-matters-most/pull/145, https://github.com/crazymanish/what-matters-most/pull/146, https://github.com/crazymanish/what-matters-most/pull/147
 
   ------------------------------------------
   

--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@
     - [x] Using Timer class https://github.com/crazymanish/what-matters-most/pull/142
     - [x] Using DispatchQueue https://github.com/crazymanish/what-matters-most/pull/143
     - [x] Practices https://github.com/crazymanish/what-matters-most/pull/141, https://github.com/crazymanish/what-matters-most/pull/142, https://github.com/crazymanish/what-matters-most/pull/143, https://github.com/crazymanish/what-matters-most/pull/144
-- [ ] Key-value Observing
+- [x] Key-value Observing
     - [x] KVO introduction https://github.com/crazymanish/what-matters-most/pull/145
     - [x] ObservableObject https://github.com/crazymanish/what-matters-most/pull/146
-    - [ ] Practices
+    - [x] Practices https://github.com/crazymanish/what-matters-most/pull/147
 
   ------------------------------------------
   


### PR DESCRIPTION
### Context
- Close ticket: #54 

### In this PR
- Base branch of below PRs:
- https://github.com/crazymanish/what-matters-most/pull/145
- https://github.com/crazymanish/what-matters-most/pull/146

### Highlights
- Key-Value Observing mostly relies on the Objective-C runtime and methods of the NSObject protocol.
- Many Objective-C classes in Apple frameworks offer some KVO-compliant properties.
- You can make your own properties observable provided they are in **a class inheriting NSObject, and marked with the `@objc dynamic`** attributes.
- You can also inherit from **ObservableObject and use @Published** for your properties. The compiler-generated **objectWillChange publisher triggers every time one of the @Published properties changes** `(but doesn’t tell you which one changed)`.
